### PR TITLE
Replace styleable parent name separator from dot to underscore

### DIFF
--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/xml/DeclareStyleableParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/xml/DeclareStyleableParser.kt
@@ -55,6 +55,7 @@ class DeclareStyleableParser @Inject constructor() : ResourceFileParser {
         val styleableValue = rFields.joinToString(separator = ",") { defaultResValue }.let { "{ ${it} }" }
 
         // Add parent styleable
+        var stylelableParentName = entry.tagName.replace(".", "_")
         rFields.add(RFieldEntry(Type.STYLEABLE, entry.tagName, styleableValue, true))
 
         return rFields.let {

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/xml/DeclareStyleableParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/xml/DeclareStyleableParser.kt
@@ -47,7 +47,8 @@ class DeclareStyleableParser @Inject constructor() : ResourceFileParser {
         val rFields = mutableSetOf<RFieldEntry>()
 
         entry.children.forEach {
-            val childName = "${entry.tagName}_${it}"
+            var childStyleName = entry.tagName.replace(".", "_")
+            val childName = "${childStyleName}_${it}"
             rFields.add(RFieldEntry(Type.STYLEABLE, childName, defaultResValue))
         }
 

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/xml/DeclareStyleableParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/xml/DeclareStyleableParser.kt
@@ -56,7 +56,7 @@ class DeclareStyleableParser @Inject constructor() : ResourceFileParser {
 
         // Add parent styleable
         var stylelableParentName = entry.tagName.replace(".", "_")
-        rFields.add(RFieldEntry(Type.STYLEABLE, entry.tagName, styleableValue, true))
+        rFields.add(RFieldEntry(Type.STYLEABLE, stylelableParentName, styleableValue, true))
 
         return rFields.let {
             ParserResult(it, Type.STYLEABLE)

--- a/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
+++ b/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
@@ -79,7 +79,7 @@ class ResToRStyleableValueParserTest : BaseBindingStubTest() {
     }
 
     @Test
-    fun `assert styleable values are parsed correctly without dot`() {
+    fun `assert styleable values are parsed correctly (dot will be replaced with underscore)`() {
         val listTemp = testResFiles(
                 TestResFile("styleable.xml",
                         contents = """

--- a/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
+++ b/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
@@ -77,4 +77,31 @@ class ResToRStyleableValueParserTest : BaseBindingStubTest() {
         assertEquals(mapOf(Type.STYLEABLE to exptectedStyleable,
             Type.ATTR to exptectedAttrs), result)
     }
+
+    @Test
+    fun `assert styleable values are parsed correctly without dot`() {
+        val listTemp = testResFiles(
+                TestResFile("styleable.xml",
+                        contents = """
+                <resources>
+                    <declare-styleable name="Base.StyleableView">
+                        <attr name="colorAttr" />
+                        <attr name="sizeAttr" />
+                    </declare-styleable>
+                </resources>
+                """.trimIndent(), path = "/src/res/values/")
+        )
+
+        val result = resToRParser.parse(listTemp, emptyList<String>()) as MutableMap<Type, MutableSet<RFieldEntry>>
+        val parentValue = "{ 0,0 }"
+        val exptectedStyleable = setOf(RFieldEntry(Type.STYLEABLE, "Base_StyleableView", parentValue, isArray = true),
+                RFieldEntry(Type.STYLEABLE, "Base_StyleableView_colorAttr", value),
+                RFieldEntry(Type.STYLEABLE, "Base_StyleableView_sizeAttr", value))
+
+        val exptectedAttrs = setOf(RFieldEntry(Type.ATTR, "colorAttr", value),
+                RFieldEntry(Type.ATTR, "sizeAttr", value))
+
+        assertEquals(mapOf(Type.STYLEABLE to exptectedStyleable,
+                Type.ATTR to exptectedAttrs), result)
+    }
 }


### PR DESCRIPTION
To handle parent name with dot.

XML:
```
<declare-styleable name="BaseTheme.AppTheme">
        <attr name="CheckboxDefaultStyle" format="reference"/>
</declare-styleable>
```

error message:
```
r-classes/com/albertjanuar/android/arjuna/R.java:7659: error: unexpected token: .
    public static int BaseTheme.AppTheme_CheckboxDefaultStyle = 0;
```