### PR TITLE
Apply `buildifier` on whole project

### DIFF
--- a/tools/auto-service/BUILD.bazel
+++ b/tools/auto-service/BUILD.bazel
@@ -1,5 +1,3 @@
-
-
 java_plugin(
     name = "auto-service-plugin",
     processor_class = "com.google.auto.service.processor.AutoServiceProcessor",
@@ -11,7 +9,7 @@ java_plugin(
 java_library(
     name = "auto-service",
     exported_plugins = [":auto-service-plugin"],
-    visibility=[ "//visibility:public" ],
+    visibility = ["//visibility:public"],
     exports = [
         "@maven//:com_google_auto_service_auto_service",
     ],

--- a/tools/binding-adapter-bridge/BUILD.bazel
+++ b/tools/binding-adapter-bridge/BUILD.bazel
@@ -1,14 +1,13 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@grab_bazel_common//tools/test:test.bzl", "grab_kt_jvm_test")
 
-
 kt_jvm_library(
     name = "binding-adapter-processor",
     srcs = glob([
         "src/main/java/**/*.kt",
     ]),
     deps = [
-        "//tools/auto-service:auto-service",
+        "//tools/auto-service",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
         "@maven//:androidx_databinding_databinding_adapters",
         "@maven//:com_google_auto_auto_common",

--- a/tools/databinding/databinding.bzl
+++ b/tools/databinding/databinding.bzl
@@ -173,14 +173,14 @@ def kt_db_android_library(
     The macro ensures that Kotlin code referenced in any XMLs are compiled first using kt_android_library
     and then uses android_library's enable_data_binding to generate required Databinding classes.
 
-    This helps in breaking circular dependency when we have android_library (databinding enabled) -> kt_android_library. 
-    In that case, Databinding classes can't be generated until resources are processed and that happens only in android_library 
+    This helps in breaking circular dependency when we have android_library (databinding enabled) -> kt_android_library.
+    In that case, Databinding classes can't be generated until resources are processed and that happens only in android_library
     target. So compiling Koltin classes becomes dependent on android_library and android_library depends on kt_android_library since
     it needs class files to process class references in XML. This macro alleviates this problem by processing resources without
-    android resources or `aapt` via a custom compiler and generates stub classes like R.java, BR.java and *Binding.java. 
+    android resources or `aapt` via a custom compiler and generates stub classes like R.java, BR.java and *Binding.java.
 
-    Then Kotlin code can be safely compiled without errors. In the final stage, the stub classes are replaced with actual classes by 
-    android_library target. 
+    Then Kotlin code can be safely compiled without errors. In the final stage, the stub classes are replaced with actual classes by
+    android_library target.
 
     It also supports @BindingAdapters written in Kotlin.
 

--- a/tools/databinding/utils.bzl
+++ b/tools/databinding/utils.bzl
@@ -8,6 +8,7 @@ def copy_file_action(ctx, in_file, out_file, file_type = ""):
         out_file: Desination where the file will be copied to.
         file_type: Metadata about the file that will be printed in progress message.
     """
+
     # TODO Replace with symlink
     ctx.actions.run_shell(
         inputs = [in_file],

--- a/tools/test-suite-generator/BUILD.bazel
+++ b/tools/test-suite-generator/BUILD.bazel
@@ -7,7 +7,7 @@ kt_jvm_library(
         "src/main/java/**/*.kt",
     ]),
     deps = [
-        "//tools/auto-service:auto-service",
+        "//tools/auto-service",
         "@maven//:com_google_auto_auto_common",
         "@maven//:com_google_auto_service_auto_service",
         "@maven//:com_squareup_javapoet",
@@ -20,7 +20,7 @@ java_plugin(
     generates_api = True,
     processor_class = "com.grab.pax.test.processor.TestSuiteGenerator",
     deps = [
-        ":test-suite-generator-lib"
+        ":test-suite-generator-lib",
     ],
 )
 
@@ -34,7 +34,7 @@ kt_jvm_test(
     name = "test-suite-generator-test",
     size = "small",
     srcs = glob([
-        "src/test/java/**/*.kt"
+        "src/test/java/**/*.kt",
     ]),
     test_class = "com.grazel.generated.TestSuite",
     deps = [

--- a/tools/test/jvm/BUILD.bazel
+++ b/tools/test/jvm/BUILD.bazel
@@ -14,7 +14,7 @@ grab_kt_jvm_test(
         "src/test/java/**/*.kt",
     ]),
     associates = [
-        ":grab_kt_jvm"
+        ":grab_kt_jvm",
     ],
     deps = [
         "@maven//:junit_junit",

--- a/tools/test/test.bzl
+++ b/tools/test/test.bzl
@@ -120,10 +120,10 @@ def _gen_test_targets(
 
             # Find package name from path
             path = path_split[0]  # src/main/java/com/grab/test
-            
+
             test_package = ""
             if path.find("src/test/java/") != -1 or path.find("src/test/kotlin/") != -1:  # TODO make this path configurable
-                path = path.split("src/test/java/")[1] if path.find("src/test/java/") != -1 else path.split("src/test/kotlin/")[1] # com/grab/test
+                path = path.split("src/test/java/")[1] if path.find("src/test/java/") != -1 else path.split("src/test/kotlin/")[1]  # com/grab/test
                 test_class = path.replace("/", ".") + "." + test_file_name  # com.grab.test.TestFile
 
                 test_target_name = test_class.replace(".", "_")
@@ -133,9 +133,9 @@ def _gen_test_targets(
                 # file to act as trigger
                 trigger = "_" + test_target_name + "_trigger"
                 native.genrule(
-                        name = trigger,
-                        outs = [test_target_name + "_Trigger.kt"],
-                        cmd = """echo "" > $@""",
+                    name = trigger,
+                    outs = [test_target_name + "_Trigger.kt"],
+                    cmd = """echo "" > $@""",
                 )
 
                 if runner_associates:


### PR DESCRIPTION
Applies buildifier on whole project. We need validation in workflows as part of PR checks and that can be done in a different PR.