### PR TITLE
Expose test's compile time resources on runtime

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,7 @@ maven_install(
         "androidx.databinding:databinding-runtime:3.4.2",
         "androidx.annotation:annotation:1.1.0",
         "com.github.tschuchortdev:kotlin-compile-testing:1.3.1",
+        "com.google.android.material:material:1.2.1",
         "javax.inject:javax.inject:1",
         "junit:junit:4.13",
     ],

--- a/tools/test/android/BUILD.bazel
+++ b/tools/test/android/BUILD.bazel
@@ -6,6 +6,9 @@ kt_android_library(
     srcs = glob([
         "src/main/java/**/*.kt",
     ]),
+    deps = [
+        "@maven//:com_google_android_material_material",
+    ],
 )
 
 grab_android_local_test(
@@ -17,6 +20,7 @@ grab_android_local_test(
         ":grab_android_local_test_lib_kt",
     ],
     deps = [
+        ":grab_android_local_test_lib",
         "@maven//:junit_junit",
     ],
 )

--- a/tools/test/android/src/main/java/com/grab/test/TestActivity.kt
+++ b/tools/test/android/src/main/java/com/grab/test/TestActivity.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.os.Bundle
 
 class TestActivity : Activity() {
+    val material_res = com.google.android.material.R.color.material_blue_grey_950
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
     }

--- a/tools/test/android/src/test/java/com/grab/test/SimpleActivityTest.kt
+++ b/tools/test/android/src/test/java/com/grab/test/SimpleActivityTest.kt
@@ -21,4 +21,10 @@ class SimpleActivityTest {
         assertEquals(null, activity.createAttributionContext("any"))
         assertEquals(false, activity.isDestroyed)
     }
+
+    @Test
+    fun `assert resource values`() {
+        val activity = TestActivity()
+        assertEquals(activity.material_res, com.google.android.material.R.color.material_blue_grey_950)
+    }
 }

--- a/tools/test/runtime_resources.bzl
+++ b/tools/test/runtime_resources.bzl
@@ -1,0 +1,35 @@
+"""
+A rule to collect all dependencies' Android resource jars that is made available
+only on compile time and get them loaded during runtime
+
+It works by iterating through the transitive compile time jars of all given 
+target and retrieving jar files that ends with `_resources.jar` into a JavaInfo
+which can then be loaded during runtime.
+"""
+
+def _runtime_resources_impl(ctx):
+    deps = ctx.attr.deps
+
+    resources_java_infos = {}
+    for target in deps:
+        if (JavaInfo in target):
+            for jar in target[JavaInfo].transitive_compile_time_jars.to_list():
+                if (jar.basename.endswith("_resources.jar")):
+                    resources_java_infos[jar.path] = JavaInfo(
+                        output_jar = jar,
+                        compile_jar = jar,
+                    )
+
+    resources_java_infos = list(resources_java_infos.values())
+    merged_java_infos = java_common.merge(resources_java_infos)
+
+    return [
+        merged_java_infos
+    ]
+
+runtime_resources = rule(
+    implementation = _runtime_resources_impl,
+    attrs = {
+        "deps": attr.label_list(),
+    },
+)

--- a/tools/test/test.bzl
+++ b/tools/test/test.bzl
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load(":runtime_resources.bzl", "runtime_resources")
 
 def grab_android_local_test(
         name,
@@ -30,13 +31,20 @@ def grab_android_local_test(
         and all valid arguments that you want to pass to the android_local_test target
         associates: associates target to allow access to internal members from the main Kotlin target
     """
+    
+    runtime_resources_name = name + "-runtime-resources"
+    runtime_resources(
+        name = runtime_resources_name,
+        deps = deps,
+    )
+
     _gen_test_targets(
         test_compile_rule_type = kt_jvm_library,
         test_runner_rule_type = kt_jvm_test,
         name = name,
         srcs = srcs,
         associates = associates,
-        deps = deps,
+        deps = deps + [":" + runtime_resources_name],
         runner_associates = False,
         test_compile_deps = [
             "@grab_bazel_common//tools/test:mockable-android-jar",


### PR DESCRIPTION
During test execution, the target's dependencies' resources is only made available during compile time but not runtime. This causes references to external resources like the material library (via `com.google.android.material.R`) to end up with a `NoClassDefFoundError`.

This change will add a rule to `grab_android_local_test` that will get the transitive compile resources jar to be available on runtime as a dependency.