### PR TITLE
Fix class_info.to_list()

### DIFF
--- a/tools/android-mock/BUILD.bazel
+++ b/tools/android-mock/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
 kt_jvm_library(
     name = "mockable-android-jar-lib",

--- a/tools/binding-adapter-bridge/BUILD.bazel
+++ b/tools/binding-adapter-bridge/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@grab_bazel_common//tools/test:test.bzl", "grab_kt_jvm_test")
 
 kt_jvm_library(

--- a/tools/build_config/build_config.bzl
+++ b/tools/build_config/build_config.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 _STRING_TYPE = "String"
 _BOOLEAN_TYPE = "Boolean"

--- a/tools/databinding/databinding.bzl
+++ b/tools/databinding/databinding.bzl
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load(":databinding_aar.bzl", "databinding_aar")
 load(":databinding_classinfo.bzl", "direct_class_infos")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load(":databinding_r_deps.bzl", "extract_r_txt_deps")
 load(":databinding_stubs.bzl", "databinding_stubs")
 

--- a/tools/databinding/databinding_stubs.bzl
+++ b/tools/databinding/databinding_stubs.bzl
@@ -51,7 +51,7 @@ def _databinding_stubs_impl(ctx):
 
     for target in deps:
         if (DataBindingV2Info in target):
-            for class_info in target[DataBindingV2Info].class_infos.to_list():
+            for class_info in target[DataBindingV2Info].class_infos:
                 if _is_direct(class_info.owner.package, tags):
                     class_infos[class_info.path] = class_info
         if (AndroidResourcesInfo in target):

--- a/tools/db-compiler-lite/BUILD
+++ b/tools/db-compiler-lite/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@grab_bazel_common//tools/test:test.bzl", "grab_kt_jvm_test")
 
 kt_jvm_library(

--- a/tools/kotlin/android.bzl
+++ b/tools/kotlin/android.bzl
@@ -1,5 +1,5 @@
 load(
-    "@io_bazel_rules_kotlin//kotlin:kotlin.bzl",
+    "@io_bazel_rules_kotlin//kotlin:jvm.bzl",
     _kt_jvm_library = "kt_jvm_library",
 )
 

--- a/tools/parcelize/parcelize.bzl
+++ b/tools/parcelize/parcelize.bzl
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_compiler_plugin", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_compiler_plugin")
 
 def parcelize_rules():
     """Create Kotlin parcelize rules

--- a/tools/test-suite-generator/BUILD.bazel
+++ b/tools/test-suite-generator/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
 kt_jvm_library(
     name = "test-suite-generator-lib",

--- a/tools/test/jvm/BUILD.bazel
+++ b/tools/test/jvm/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@grab_bazel_common//tools/test:test.bzl", "grab_kt_jvm_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 kt_jvm_library(
     name = "grab_kt_jvm",

--- a/tools/test/test.bzl
+++ b/tools/test/test.bzl
@@ -1,5 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 load(":runtime_resources.bzl", "runtime_resources")
 
 def grab_android_local_test(


### PR DESCRIPTION
The first commit addresses a crash. On master, with Bazel 4.2.2 (I'm not sure if this was a change stemming from Bazel 4):

```
$ bazel build //...
DEBUG: /private/var/tmp/_bazel_p/a48d838470da09ddcc3c8b96c3b3efad/external/io_bazel_rules_kotlin/kotlin/kotlin.bzl:116:10: kt_jvm_library should be loaded from //kotlin:jvm.bzl
DEBUG: /private/var/tmp/_bazel_p/a48d838470da09ddcc3c8b96c3b3efad/external/io_bazel_rules_kotlin/kotlin/kotlin.bzl:116:10: kt_jvm_library should be loaded from //kotlin:jvm.bzl
DEBUG: /private/var/tmp/_bazel_p/a48d838470da09ddcc3c8b96c3b3efad/external/io_bazel_rules_kotlin/kotlin/kotlin.bzl:116:10: kt_jvm_library should be loaded from //kotlin:jvm.bzl
ERROR: /Users/p/Code/examples/bazel-kt-databinding-crash/BUILD:17:22: in databinding_stubs rule //:app_lib-stubs:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_p/a48d838470da09ddcc3c8b96c3b3efad/external/grab_bazel_common/tools/databinding/databinding_stubs.bzl", line 54, column 68, in _databinding_stubs_impl
		for class_info in target[DataBindingV2Info].class_infos.to_list():
Error: 'list' value has no field or method 'to_list'
ERROR: Analysis of target '//:r-classes' failed; build aborted: Analysis of target '//:app_lib-stubs' failed
INFO: Elapsed time: 15.201s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (12 packages loaded, 721 targets configured)
```

This PR also changes the import path for kt_jvm_library to remove the debug messages from rules_kotlin. LMK if you'd rather have that in a separate PR—happy to split it out.