### PR TITLE
Accept names with colon for XML namespace

### DIFF
--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/generator/ResToRClassGenerator.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/generator/ResToRClassGenerator.kt
@@ -73,7 +73,7 @@ class ResToRClassGeneratorImpl constructor(
                         .toTypedArray()
 
                     fields.add(
-                        FieldSpec.builder(type, it.name.replace(":", "_"))
+                        FieldSpec.builder(type, it.name)
                             .addModifiers(*modifiers)
                             .initializer(it.value)
                             .build()

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/generator/ResToRClassGenerator.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/generator/ResToRClassGenerator.kt
@@ -73,7 +73,7 @@ class ResToRClassGeneratorImpl constructor(
                         .toTypedArray()
 
                     fields.add(
-                        FieldSpec.builder(type, it.name)
+                        FieldSpec.builder(type, it.name.replace(":", "_"))
                             .addModifiers(*modifiers)
                             .initializer(it.value)
                             .build()

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/ResToRParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/ResToRParser.kt
@@ -220,7 +220,7 @@ class ResToRParserImpl constructor(
                 continue
             }
 
-            val childName = xpp.attributeName()
+            val childName = xpp.attributeName().replace(":", "_")
             // Add every child as a dependent for Parent node
             children.add(childName)
 

--- a/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
+++ b/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
@@ -63,13 +63,13 @@ class ResToRStyleableValueParserTest : BaseBindingStubTest() {
             RFieldEntry(Type.STYLEABLE, "StyleableView", parentValue, isArray = true),
             RFieldEntry(Type.STYLEABLE, "StyleableView_colorAttr", value),
             RFieldEntry(Type.STYLEABLE, "StyleableView_sizeAttr", value),
-            RFieldEntry(Type.STYLEABLE, "StyleableView_android:drawableTint", value),
+            RFieldEntry(Type.STYLEABLE, "StyleableView_android_drawableTint", value),
         )
 
         val exptectedAttrs = setOf(
             RFieldEntry(Type.ATTR, "colorAttr", value),
             RFieldEntry(Type.ATTR, "sizeAttr", value),
-            RFieldEntry(Type.ATTR, "android:drawableTint", value),
+            RFieldEntry(Type.ATTR, "android_drawableTint", value),
         )
 
         assertEquals(

--- a/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
+++ b/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/rclass/parser/ResToRStyleableValueParserTest.kt
@@ -47,6 +47,7 @@ class ResToRStyleableValueParserTest : BaseBindingStubTest() {
                     <declare-styleable name="StyleableView">
                         <attr name="colorAttr" />
                         <attr name="sizeAttr" />
+                        <attr name="android:drawableTint" format="reference" />
                     </declare-styleable>
                 </resources>
                 """.trimIndent(), path = "/src/res/values/"
@@ -57,16 +58,18 @@ class ResToRStyleableValueParserTest : BaseBindingStubTest() {
             listTemp,
             emptyList<String>()
         ) as MutableMap<Type, MutableSet<RFieldEntry>>
-        val parentValue = "{ 0,0 }"
+        val parentValue = "{ 0,0,0 }"
         val exptectedStyleable = setOf(
             RFieldEntry(Type.STYLEABLE, "StyleableView", parentValue, isArray = true),
             RFieldEntry(Type.STYLEABLE, "StyleableView_colorAttr", value),
-            RFieldEntry(Type.STYLEABLE, "StyleableView_sizeAttr", value)
+            RFieldEntry(Type.STYLEABLE, "StyleableView_sizeAttr", value),
+            RFieldEntry(Type.STYLEABLE, "StyleableView_android:drawableTint", value),
         )
 
         val exptectedAttrs = setOf(
             RFieldEntry(Type.ATTR, "colorAttr", value),
-            RFieldEntry(Type.ATTR, "sizeAttr", value)
+            RFieldEntry(Type.ATTR, "sizeAttr", value),
+            RFieldEntry(Type.ATTR, "android:drawableTint", value),
         )
 
         assertEquals(


### PR DESCRIPTION
It is not uncommon to have attrs defined on a custom view that are in the Android XML NS, e.g.

```xml
<resources>
    <declare-styleable name="IconToggleButton">
        <attr name="android:drawableTint" format="reference" />
        <attr name="icon" format="reference" />
        <attr name="colorTheme" format="enum">
            <enum name="DEFAULT" value="0" />
            <enum name="DARK" value="1" />
            <enum name="CREAM" value="2" />
        </attr>
        <attr name="themeCream" format="boolean" />
        <attr name="themeDark" format="boolean" />
    </declare-styleable>
</resources>
```

`android:drawableTint` here lets users set familiar attributes on custom views.

In order to support this, Gradle converts it to, in R.txt:

```
int styleable IconToggleButton_android_drawableTint 5
```

This suggests that the right way to account for it is to replace invalid characters with an underscore. It is possible there are more than this that should be allowed, but colon at least is probably indicative of an XML namespace, so it should be valid.

Fixes #13 