### PR TITLE
Handle cases of using class with generics for `@BindingAdapter` in binding-adapter-bridge

### DIFF
--- a/tools/binding-adapter-bridge/src/main/java/com/grab/pax/binding/processor/BindingAdapterProcessor.kt
+++ b/tools/binding-adapter-bridge/src/main/java/com/grab/pax/binding/processor/BindingAdapterProcessor.kt
@@ -76,8 +76,10 @@ class BindingAdapterProcessor : BasicAnnotationProcessor(),
                             .addParameters(params.map { variableElement ->
                                 ParameterSpec.get(variableElement)
                             })
-                            .addStatement(buildStatement(methodName, params, returns), parentClass)
-                            .addTypeVariables(typeParams.map { TypeVariableName.get(it) })
+                            .addStatement(
+                                buildStatement(methodName, params, returns),
+                                buildParentClassName(parentClass)
+                            ).addTypeVariables(typeParams.map { TypeVariableName.get(it) })
                             .build()
                     } else null
                 }
@@ -97,6 +99,14 @@ class BindingAdapterProcessor : BasicAnnotationProcessor(),
 
     private fun buildClassName(packageName: String): String {
         return packageName.replace(".", "_") + GeneratedSuffix
+    }
+
+    private fun buildParentClassName(parentClass: Element): ClassName {
+        val packageElement = processingEnv.elementUtils.getPackageOf(parentClass)
+        return ClassName.get(
+            packageElement.qualifiedName.toString(),
+            parentClass.simpleName.toString() // Strip type params since we only access the class statically
+        )
     }
 
     private fun buildStatement(

--- a/tools/binding-adapter-bridge/src/test/java/com/grab/pax/binding/processor/BindingAdapterProcessorTest.kt
+++ b/tools/binding-adapter-bridge/src/test/java/com/grab/pax/binding/processor/BindingAdapterProcessorTest.kt
@@ -85,6 +85,16 @@ fun <T : Node> Node.genericsUpdateNode(node: T, value: Int) {
     updateNode(node, value)
 }
 
+class CompanionTest<T> {
+    companion object Databinding {
+        @BindingAdapter(TEST_BIND)
+        @JvmStatic
+        fun <T : Node> companionUpdateNode(node: T, value: Int) {
+            updateNode(node, value)
+        }
+    }
+}
+
 class BindingAdapterProcessorTest {
 
     @Test
@@ -156,6 +166,11 @@ class BindingAdapterProcessorTest {
     @Test
     fun `when inverse binding adapters are used, assert proxy forwards to Kotlin implementation`() {
         assertNodeUpdate(com_grab_pax_binding_processor_Binding_Adapter_Stub::getUpdateNode)
+    }
+
+    @Test
+    fun `when binding adapters in named companion object, assert proxy forwards to Kotlin implementation`() {
+        assertNodeUpdate(com_grab_pax_binding_processor_Binding_Adapter_Stub::companionUpdateNode)
     }
 
     private fun assertNodeUpdate(updateFunction: (Node, Int) -> Unit) {


### PR DESCRIPTION
Support cases where `@BindingAdapter` is statically declared in a class that uses generic in its type params. This change fixes code generation to not generate generic information in generated code for those classes since static access is invalid in Java/Kotlin.

Fixes #16