### PR TITLE
Avoid dedicated `android_library` target for `res_value` and instead compile resources directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,27 +60,21 @@ build_config(
 ```
    
 ### Res values   
-`resValue` strings support for Android Projects
+Gradle's `resValue` strings support for Android Projects
 
 ```python
 load("@grab_bazel_common//tools/res_value:res_value.bzl", "res_value")
-# Define resValues
-res_value(
-    name = "app-res-value",
-    custom_package = "com.grab.playground",
-    manifest = "src/main/AndroidManifest.xml",
-    strings = {
-        "prefix": "app",
-        "field": "debug"
-    },
-)
-
 # Usage of defined resValues
 android_library(
-    deps = [
-        ":app-res-value",
+    resource_files = [
         ...
-    ],
+    ] + res_value(
+        name = "app-res-value",
+        strings = {
+            "prefix": "app",
+            "field": "debug"
+        },
+    ),
 )
 ```   
 

--- a/tools/res_value/res_value.bzl
+++ b/tools/res_value/res_value.bzl
@@ -14,38 +14,27 @@ def _generate_xml(items):
 
 def res_value(
         name,
-        custom_package,
-        manifest,
         strings = {}):
-    """Generates an android library target that exposes values specified in strings
-    as generated resources xml.
+    """Generates an resources xml with the given strings.
 
     Usage:
-    Provide the string variables in the string dictionary and add a dependency on this target.
+    Provide the string variables in the string dictionary and add this target in resource_files of a target.
 
     Args:
-        name: name for this target,
-        custom_package: package used for Android resource processing,
-        manifest: required when resource_files are defined,
-        strings: string value of type string
+        name: name for this target
+        strings: string values
     """
 
-    res_value_file = "src/main/res/values/gen_strings.xml"
-    strings_statements = _res_statement(strings)
-    xml_generation = _generate_xml(strings_statements)
+    resources = "src/main/res/values/gen_strings.xml"
+    statements = _res_statement(strings)
+    xml = _generate_xml(statements)
 
-    cmd = """echo "{xml_generation}" > $@""".format(xml_generation = xml_generation)
+    cmd = """echo "{xml}" > $@""".format(xml = xml)
 
     native.genrule(
         name = "_" + name,
-        outs = [res_value_file],
+        outs = [resources],
         message = "Generating %s's resources" % (native.package_name()),
         cmd = cmd,
     )
-
-    native.android_library(
-        name = name,
-        manifest = manifest,
-        custom_package = custom_package,
-        resource_files = [res_value_file],
-    )
+    return [resources]


### PR DESCRIPTION
Previously `res_value` generates a dedicated `android_library` target just for hosting generated resource values. This change instead adds the generated xml as the output of `res_value` so that it can be used in `resource_files` directly. 

