### PR TITLE
Prefix R classes with name to avoid conflicts

### DIFF
--- a/tools/databinding/databinding.bzl
+++ b/tools/databinding/databinding.bzl
@@ -82,7 +82,7 @@ def kt_db_android_library(
     binding_classes_sources = databinding_stubs_target + "_binding.srcjar"
 
     r_classes_sources = databinding_stubs_target + "_r.srcjar"
-    r_classes = "r-classes"
+    r_classes = name + "-r-classes"
 
     # R classes are not meant to be packaged into the binary, so export it as java_library but don't
     # link it.

--- a/tools/res_value/res_value.bzl
+++ b/tools/res_value/res_value.bzl
@@ -25,7 +25,7 @@ def res_value(
         strings: string values
     """
 
-    resources = "src/main/res/values/gen_strings.xml"
+    resources = "src/main/res/values/gen_strings_%s.xml" % name
     statements = _res_statement(strings)
     xml = _generate_xml(statements)
 


### PR DESCRIPTION
Without this, using two `kt_db_android_library` targets in the same package fails with:

```
	File "/mypath/app/BUILD.bazel", line 251, column 22, in <toplevel>
		kt_db_android_library(
	File "/private/var/tmp/_bazel_p/c1a9d93c5d307e720ae1d0573bce325b/external/grab_bazel_common/tools/databinding/databinding.bzl", line 89, column 24, in kt_db_android_library
		native.java_library(
Error in java_library: java_library rule 'r-classes' in package 'app' conflicts with existing java_library rule, defined at /mypath/app/BUILD.bazel:230:22
```