### PR TITLE
Implement multiplexing worker support for databinding stub generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ android_library(
 
 ### Databinding 
 Provides a macro which in most cases can be used as a drop-in replacement to `kt_android_library` to enable support for Kotlin code when using databinding. [Details](https://github.com/grab/grab-bazel-common/blob/documentation/tools/databinding/databinding.bzl).
+Worker support for some of the internal actions can be enabled by `build --strategy=DatabindingStubs=worker`.
 
 ```python
 load("@grab_bazel_common//tools/databinding:databinding.bzl", "kt_db_android_library")

--- a/src/main/proto/BUILD.bazel
+++ b/src/main/proto/BUILD.bazel
@@ -1,0 +1,5 @@
+alias(
+    name = "worker_protocol_java_proto",
+    actual = "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+    visibility = ["//visibility:public"],
+)

--- a/src/main/proto/BUILD.bazel
+++ b/src/main/proto/BUILD.bazel
@@ -1,5 +1,0 @@
-alias(
-    name = "worker_protocol_java_proto",
-    actual = "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
-    visibility = ["//visibility:public"],
-)

--- a/tools/databinding/databinding_stubs.bzl
+++ b/tools/databinding/databinding_stubs.bzl
@@ -71,6 +71,9 @@ def _databinding_stubs_impl(ctx):
 
     # Args for compiler
     args = ctx.actions.args()
+    args.set_param_file_format("multiline")
+    args.use_param_file("--flagfile=%s", use_always = True)
+
     args.add("--package", custom_package)
     args.add_joined(
         "--resource-files",
@@ -106,6 +109,7 @@ def _databinding_stubs_impl(ctx):
         executable = ctx.executable._compiler,
         arguments = [args],
         progress_message = "%s %s" % (mnemonic, ctx.label),
+        execution_requirements = {"supports-workers": "1"},
     )
 
     return [

--- a/tools/databinding/databinding_stubs.bzl
+++ b/tools/databinding/databinding_stubs.bzl
@@ -109,7 +109,7 @@ def _databinding_stubs_impl(ctx):
         executable = ctx.executable._compiler,
         arguments = [args],
         progress_message = "%s %s" % (mnemonic, ctx.label),
-        execution_requirements = {"supports-workers": "1"},
+        execution_requirements = {"supports-workers": "1", "supports-multiplex-workers": "1"},
     )
 
     return [

--- a/tools/db-compiler-lite/BUILD
+++ b/tools/db-compiler-lite/BUILD
@@ -15,7 +15,6 @@ kt_jvm_library(
         "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
         "@maven//:androidx_databinding_databinding_common",
         "@maven//:com_github_ajalt_clikt",
-        "@maven//:com_google_guava_guava",
         "@maven//:com_squareup_javapoet",
         "@maven//:com_squareup_moshi_moshi",
         "@maven//:net_sf_kxml_kxml2",

--- a/tools/db-compiler-lite/BUILD
+++ b/tools/db-compiler-lite/BUILD
@@ -15,6 +15,7 @@ kt_jvm_library(
         "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
         "@maven//:androidx_databinding_databinding_common",
         "@maven//:com_github_ajalt_clikt",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_squareup_javapoet",
         "@maven//:com_squareup_moshi_moshi",
         "@maven//:net_sf_kxml_kxml2",

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/BindingsStubComponent.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/BindingsStubComponent.kt
@@ -23,23 +23,26 @@ import com.grab.databinding.stub.binding.parser.LayoutBindingsParser
 import com.grab.databinding.stub.brclass.BrClassGenerator
 import com.grab.databinding.stub.brclass.BrClassModule
 import com.grab.databinding.stub.common.*
-import com.grab.databinding.stub.rclass.di.ResToRClassModule
+import com.grab.databinding.stub.rclass.ResourceParserModule
 import com.grab.databinding.stub.rclass.generator.RClassModule
 import com.grab.databinding.stub.rclass.generator.ResToRClassGenerator
 import dagger.BindsInstance
 import dagger.Component
 import java.io.File
 import javax.inject.Named
-import javax.inject.Singleton
+import javax.inject.Scope
 
-@Singleton
+@Scope
+annotation class AaptScope
+
+@AaptScope
 @Component(
     modules = [
         RClassModule::class,
         BindingClassModule::class,
         BrClassModule::class,
         BindingsParserModule::class,
-        ResToRClassModule::class,
+        ResourceParserModule::class,
         SrcJarPackageModule::class
     ]
 )
@@ -55,7 +58,7 @@ interface BindingsStubComponent {
         /**
          * Construct the [BindingsStubComponent] injector.
          *
-         * @param outputDir The output dir root where the files should be generated
+         * @param baseDir The base directory where files will be written to
          * @param packageName The package name of the target for which stubs are to be generated
          * @param layoutFiles The list of all layout xmls
          * @param resourceFiles The list of all resource files for compilation
@@ -65,7 +68,7 @@ interface BindingsStubComponent {
          * and not contain any transitive entries
          */
         fun create(
-            @BindsInstance @Named(OUTPUT) outputDir: File?,
+            @BindsInstance @Named(BASE_DIR) baseDir: File,
             @BindsInstance @Named(PACKAGE_NAME) packageName: String,
             @BindsInstance @Named(LAYOUT_FILES) layoutFiles: List<File>,
             @BindsInstance @Named(RES_FILES) resourceFiles: List<File>,

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/parser/LayoutBindingsParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/parser/LayoutBindingsParser.kt
@@ -16,6 +16,7 @@
 
 package com.grab.databinding.stub.binding.parser
 
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.binding.store.DEPS
 import com.grab.databinding.stub.binding.store.LOCAL
 import com.grab.databinding.stub.binding.store.LayoutTypeStore
@@ -92,7 +93,7 @@ interface BindingsParserModule {
  */
 private typealias ImportedTypes = MutableMap<String /* type name */, TypeName>
 
-@Singleton
+@AaptScope
 class DefaultLayoutBindingsParser
 @Inject
 constructor(

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/store/BindingClassJsonParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/store/BindingClassJsonParser.kt
@@ -16,6 +16,7 @@
 
 package com.grab.databinding.stub.binding.store
 
+import com.grab.databinding.stub.AaptScope
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonReader.Token
@@ -25,7 +26,6 @@ import dagger.Binds
 import dagger.Module
 import java.io.File
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.LazyThreadSafetyMode.NONE
 
 
@@ -48,7 +48,7 @@ interface BindingClassJsonParserModule {
     fun CachingBindingClassJsonParser.cachingParser(): BindingClassJsonParser
 }
 
-@Singleton
+@AaptScope
 class CachingBindingClassJsonParser
 @Inject
 constructor() : BindingClassJsonParser {

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/store/LayoutTypeStore.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/store/LayoutTypeStore.kt
@@ -16,6 +16,7 @@
 
 package com.grab.databinding.stub.binding.store
 
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.common.CLASS_INFOS
 import com.grab.databinding.stub.common.LAYOUT_FILES
 import com.grab.databinding.stub.common.PACKAGE_NAME
@@ -68,7 +69,7 @@ interface LayoutStoreModule {
  * This class infers the generated class name from the layout name itself. For example, for
  * `simple_layout`, the generated class name will be `<package-name>.databinding.SimpleLayoutBinding`
  */
-@Singleton
+@AaptScope
 class LocalModuleLayoutTypeStore
 @Inject
 constructor(
@@ -106,7 +107,7 @@ constructor(
  * @param bindingClassJsonParser [BindingClassJsonParser] implementation that will be used to parse
  *                     contents of each binding class json file.
  */
-@Singleton
+@AaptScope
 class DependenciesLayoutTypeStore
 @Inject
 constructor(

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/brclass/BrClassGenerator.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/brclass/BrClassGenerator.kt
@@ -16,10 +16,11 @@
 
 package com.grab.databinding.stub.brclass
 
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.binding.parser.LayoutBindingData
+import com.grab.databinding.stub.common.BASE_DIR
 import com.grab.databinding.stub.common.Generator
-import com.grab.databinding.stub.common.OUTPUT
-import com.grab.databinding.stub.common.R_CLASS_OUTPUT
+import com.grab.databinding.stub.common.R_CLASS_OUTPUT_DIR
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeName.INT
@@ -29,14 +30,11 @@ import dagger.Module
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Singleton
 import javax.lang.model.element.Modifier.PUBLIC
 import javax.lang.model.element.Modifier.STATIC
 
 interface BrClassGenerator : Generator {
-    override val defaultDirName get() = R_CLASS_OUTPUT
-
-    fun generate(packageName: String, layoutBindings: List<LayoutBindingData>)
+    fun generate(packageName: String, layoutBindings: List<LayoutBindingData>): File
 }
 
 @Module
@@ -45,12 +43,12 @@ interface BrClassModule {
     fun DefaultBrClassGenerator.provide(): BrClassGenerator
 }
 
-@Singleton
+@AaptScope
 class DefaultBrClassGenerator
 @Inject
 constructor(
-    @Named(OUTPUT)
-    override val preferredDir: File?
+    @Named(BASE_DIR)
+    override val baseDir: File
 ) : BrClassGenerator {
 
     companion object {
@@ -63,7 +61,8 @@ constructor(
         )
     }
 
-    override fun generate(packageName: String, layoutBindings: List<LayoutBindingData>) {
+    override fun generate(packageName: String, layoutBindings: List<LayoutBindingData>): File {
+        val outputDir = File(baseDir, R_CLASS_OUTPUT_DIR)
         val fields = DEFAULT_FIELDS + layoutBindings
             .asSequence()
             .flatMap { it.bindables.asSequence() }
@@ -88,5 +87,6 @@ constructor(
             .build()
             .writeTo(outputDir)
         logFile(packageName, brType.name)
+        return outputDir
     }
 }

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/Constants.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/Constants.kt
@@ -16,12 +16,14 @@
 
 package com.grab.databinding.stub.common
 
-const val OUTPUT = "OUTPUT"
+const val BASE_DIR = "BASE_DIR"
+const val R_CLASS_OUTPUT_DIR = "rclasses"
+const val DATABINDING_OUTPUT_DIR = "databinding"
+
 const val PACKAGE_NAME = "PACKAGE_NAME"
 const val LAYOUT_FILES = "LAYOUT_FILES"
 const val RES_FILES = "RES_FILES"
 const val CLASS_INFOS = "CLASS_INFO"
 const val R_TXTS = "R_TXT_ZIP"
-const val R_CLASS_OUTPUT = "r-classes"
-const val DB_STUBS_OUTPUT = "db-stubs"
+
 const val NON_TRANSITIVE_R = "NON_TRANSITIVE_R"

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/Generator.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/Generator.kt
@@ -19,15 +19,7 @@ package com.grab.databinding.stub.common
 import java.io.File
 
 interface Generator {
-    val preferredDir: File?
-
-    val defaultDirName: String
-
-    val outputDir: File
-        get() = when {
-            preferredDir != null -> File(preferredDir, defaultDirName)
-            else -> File(defaultDirName)
-        }
+    val baseDir: File
 
     fun logFile(packageName: String, typeName: String) {
 //        val fileName = Paths.get(

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/SrcJarPackager.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/SrcJarPackager.kt
@@ -1,5 +1,6 @@
 package com.grab.databinding.stub.common
 
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.util.jars.SourceJarCreator
 import dagger.Binds
 import dagger.Module
@@ -30,7 +31,7 @@ interface SrcJarPackageModule {
     fun DefaultSrcJarPackager.packager(): SrcJarPackager
 }
 
-@Singleton
+@AaptScope
 class DefaultSrcJarPackager @Inject constructor() : SrcJarPackager {
 
     override fun packageSrcJar(inputDir: File, outputFile: File, verbose: Boolean) {

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/main.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/main.kt
@@ -20,9 +20,9 @@ import io.bazel.Status
 import io.bazel.Worker
 
 fun main(args: Array<String>) {
-    Worker.from(args = args.toList()).run { args ->
+    Worker.from(args = args.toList()).run { cliArgs ->
         try {
-            BindingStubCommand().main(args)
+            BindingStubCommand().main(cliArgs)
             Status.Success
         } catch (e: Exception) {
             e.printStackTrace()

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/ResToRClassModule.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/ResToRClassModule.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.grab.databinding.stub.rclass.di
+package com.grab.databinding.stub.rclass
 
-import com.grab.databinding.stub.common.OUTPUT
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.rclass.generator.ResToRClassGenerator
 import com.grab.databinding.stub.rclass.generator.ResToRClassGeneratorImpl
 import com.grab.databinding.stub.rclass.parser.DefaultResToRParser
@@ -27,11 +27,7 @@ import com.grab.databinding.stub.rclass.parser.xml.*
 import dagger.Binds
 import dagger.MapKey
 import dagger.Module
-import dagger.Provides
 import dagger.multibindings.IntoMap
-import java.io.File
-import javax.inject.Named
-import javax.inject.Singleton
 
 @MapKey
 annotation class ParserKey(val value: ParserType)
@@ -64,19 +60,10 @@ interface ResourceParserModule {
     fun DefaultXmlParser.defaultXmlParser(): ResourceFileParser
 
     @Binds
-    @Singleton
+    @AaptScope
     fun DefaultResToRParser.defaultResToRParser(): ResToRParser
-}
 
-@Module(includes = [ResourceParserModule::class])
-object ResToRClassModule {
-    @JvmStatic
-    @Provides
-    @Singleton
-    fun resToRClassGeneratorImpl(
-        @Named(OUTPUT) dir: File?,
-        resToRParser: ResToRParser
-    ): ResToRClassGenerator {
-        return ResToRClassGeneratorImpl(resToRParser, dir)
-    }
+    @Binds
+    @AaptScope
+    fun ResToRClassGeneratorImpl.resToRClassGenerator(): ResToRClassGenerator
 }

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/generator/RClassGenerator.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/generator/RClassGenerator.kt
@@ -16,10 +16,11 @@
 
 package com.grab.databinding.stub.rclass.generator
 
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.binding.parser.LayoutBindingData
+import com.grab.databinding.stub.common.BASE_DIR
 import com.grab.databinding.stub.common.Generator
-import com.grab.databinding.stub.common.OUTPUT
-import com.grab.databinding.stub.common.R_CLASS_OUTPUT
+import com.grab.databinding.stub.common.R_CLASS_OUTPUT_DIR
 import com.grab.databinding.stub.rclass.parser.DefaultRTxtParser
 import com.grab.databinding.stub.rclass.parser.RFieldEntry
 import com.grab.databinding.stub.rclass.parser.RTxtParser
@@ -33,13 +34,10 @@ import dagger.Module
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Singleton
 import javax.lang.model.element.Modifier.*
 
 //TODO: remove if not used
 interface RClassGenerator : Generator {
-    override val defaultDirName get() = R_CLASS_OUTPUT
-
     fun generate(
         packageName: String,
         content: List<String>,
@@ -56,13 +54,13 @@ interface RClassModule {
     fun DefaultRTxtParser.rTxtParser(): RTxtParser
 }
 
-@Singleton
+@AaptScope
 class DefaultRClassGenerator
 @Inject
 constructor(
+    @Named(BASE_DIR)
+    override val baseDir: File,
     private val rTxtParser: RTxtParser,
-    @Named(OUTPUT)
-    override val preferredDir: File?
 ) : RClassGenerator {
 
     private fun RFieldEntry.toFieldSpec(): FieldSpec? {
@@ -102,7 +100,7 @@ constructor(
             .let { type ->
                 JavaFile.builder(rClass.packageName, type)
                     .build()
-                    .writeTo(outputDir)
+                    .writeTo(File(baseDir, R_CLASS_OUTPUT_DIR))
                 logFile(rClass.packageName, type.name)
             }
     }

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/RTxtParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/RTxtParser.kt
@@ -16,6 +16,7 @@
 
 package com.grab.databinding.stub.rclass.parser
 
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.binding.parser.LayoutBindingData
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -100,7 +101,7 @@ interface RTxtParser {
     ): RClass
 }
 
-@Singleton
+@AaptScope
 class DefaultRTxtParser
 @Inject
 constructor() : RTxtParser {

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/ResToRParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/ResToRParser.kt
@@ -16,6 +16,7 @@
 
 package com.grab.databinding.stub.rclass.parser
 
+import com.grab.databinding.stub.AaptScope
 import com.grab.databinding.stub.common.NON_TRANSITIVE_R
 import com.grab.databinding.stub.util.*
 import org.xmlpull.v1.XmlPullParser
@@ -40,7 +41,7 @@ private const val ID_DEFINITION_PREFIX = "id/"
 private const val ANDROID_ID = "android:id"
 private const val TAG_TYPE = "type"
 
-@Singleton
+@AaptScope
 class DefaultResToRParser @Inject constructor(
     private val parsers: Map<ParserType, @JvmSuppressWildcards ResourceFileParser>,
     @param:Named(NON_TRANSITIVE_R) private val nonTransitiveRClass: Boolean

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/util/Utils.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/util/Utils.kt
@@ -44,5 +44,5 @@ fun String.toLayoutBindingName(): String {
 }
 
 fun enumTypeValue(name: String): XmlTypeValues {
-    return enumValues<XmlTypeValues>().first() { it.entry == name}
+    return enumValues<XmlTypeValues>().first() { it.entry == name }
 }

--- a/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/binding/generator/DefaultBindingClassGeneratorTest.kt
+++ b/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/binding/generator/DefaultBindingClassGeneratorTest.kt
@@ -20,7 +20,7 @@ import com.grab.databinding.stub.binding.parser.Binding
 import com.grab.databinding.stub.binding.parser.BindingType
 import com.grab.databinding.stub.binding.parser.LayoutBindingData
 import com.grab.databinding.stub.common.BaseBindingStubTest
-import com.grab.databinding.stub.common.DB_STUBS_OUTPUT
+import com.grab.databinding.stub.common.DATABINDING_OUTPUT_DIR
 import com.squareup.javapoet.ClassName
 import org.junit.Before
 import org.junit.Test
@@ -33,32 +33,30 @@ import kotlin.test.assertTrue
 class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
 
     private lateinit var defaultBindingClassGenerator: DefaultBindingClassGenerator
-    private lateinit var outputDir: File
+    private lateinit var baseDir: File
     private lateinit var layoutBinding: LayoutBindingData
 
     private val testPackage = "test"
     private val className = "com.package.Class"
     private val layoutName = "SimpleBinding"
     private val bindableName = "vm"
-    private val bindableNameWithUnderscoe = "vm_test"
+    private val bindableNameWithUnderscore = "vm_test"
     private val bindingName = "time_display"
     private val bindingFragmentRawName = "fragment_view"
 
-    private val generatedFileContents
-        get() = File(
-            outputDir,
-            Paths.get(
-                DB_STUBS_OUTPUT,
-                testPackage,
-                "databinding",
-                "$layoutName.java"
-            ).toString()
-        ).readText()
+    private fun generatedFileContents(outputDir: File) = File(
+        outputDir,
+        Paths.get(
+            testPackage,
+            DATABINDING_OUTPUT_DIR,
+            "$layoutName.java"
+        ).toString()
+    ).readText()
 
     @Before
     fun setup() {
-        outputDir = temporaryFolder.newFolder()
-        defaultBindingClassGenerator = DefaultBindingClassGenerator(outputDir)
+        baseDir = temporaryFolder.newFolder()
+        defaultBindingClassGenerator = DefaultBindingClassGenerator(baseDir)
         val testClassName = ClassName.bestGuess(className)
         layoutBinding = LayoutBindingData(
             layoutName = layoutName,
@@ -76,7 +74,7 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
                     bindingType = BindingType.Variable
                 ),
                 Binding(
-                    rawName = bindableNameWithUnderscoe,
+                    rawName = bindableNameWithUnderscore,
                     typeName = testClassName,
                     bindingType = BindingType.Variable
                 )
@@ -98,9 +96,9 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
 
     @Test
     fun `assert constructor method has binding information`() {
-        defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
+        val output = defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
         assertTrue("Constructor arguments contain bindings") {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  protected SimpleBinding(Object _bindingComponent, View _root, int _localFieldCount,
       Class timeDisplay) {"""
             )
@@ -109,9 +107,9 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
 
     @Test
     fun `assert inflate methods are generated`() {
-        defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
+        val output = defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
         assertTrue() {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @NonNull
   public static SimpleBinding inflate(LayoutInflater inflater, ViewGroup root,
       boolean attachToRoot) {"""
@@ -119,7 +117,7 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
         }
 
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @NonNull
   public static SimpleBinding inflate(LayoutInflater inflater, ViewGroup root, boolean attachToRoot,
       Object component) {"""
@@ -127,7 +125,7 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
         }
 
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @NonNull
   public static SimpleBinding inflate(LayoutInflater inflater) {"""
             )
@@ -136,21 +134,21 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
 
     @Test
     fun `assert public binding fields are generated`() {
-        defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
+        val output = defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @NonNull
   public final Class timeDisplay;"""
             )
         }
         assertFalse("Invalid binding types are not considered") {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @NonNull
   public final fragment fragmentView;"""
             )
         }
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @Bindable
   protected Class mVm;"""
             )
@@ -159,25 +157,25 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
 
     @Test
     fun `assert bindable setters and getters are generated`() {
-        defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
+        val output = defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  public abstract void setVm(Class var1);"""
             )
         }
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @Nullable
   public Class getVm() {"""
             )
         }
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  public abstract void setVmTest(Class var1);"""
             )
         }
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @Nullable
   public Class getVmTest() {"""
             )
@@ -186,15 +184,15 @@ class DefaultBindingClassGeneratorTest : BaseBindingStubTest() {
 
     @Test
     fun `assert bind mehods are generated`() {
-        defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
+        val output = defaultBindingClassGenerator.generate(testPackage, listOf(layoutBinding))
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @NonNull
   public static SimpleBinding bind(View view) {"""
             )
         }
         assertTrue {
-            generatedFileContents.contains(
+            generatedFileContents(output).contains(
                 """  @NonNull
   public static SimpleBinding bind(View view, Object component) {"""
             )

--- a/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/brclass/DefaultBrClassGeneratorTest.kt
+++ b/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/brclass/DefaultBrClassGeneratorTest.kt
@@ -20,7 +20,7 @@ import com.grab.databinding.stub.binding.parser.Binding
 import com.grab.databinding.stub.binding.parser.BindingType
 import com.grab.databinding.stub.binding.parser.LayoutBindingData
 import com.grab.databinding.stub.common.BaseBindingStubTest
-import com.grab.databinding.stub.common.R_CLASS_OUTPUT
+import com.grab.databinding.stub.common.R_CLASS_OUTPUT_DIR
 import com.squareup.javapoet.ClassName
 import org.junit.Before
 import org.junit.Test
@@ -30,20 +30,19 @@ import kotlin.test.assertTrue
 
 class DefaultBrClassGeneratorTest : BaseBindingStubTest() {
     private lateinit var brClassGenerator: BrClassGenerator
-    private lateinit var outputDir: File
+    private lateinit var baseDir: File
     private lateinit var layoutBinding: LayoutBindingData
     private val packageName = "packageName"
 
-    private val generatedFileContents
-        get() = File(
-            outputDir,
-            Paths.get(R_CLASS_OUTPUT, packageName, "BR.java").toString()
-        ).readText()
+    private fun generatedFileContents(outputDir: File) = File(
+        outputDir,
+        Paths.get(packageName, "BR.java").toString()
+    ).readText()
 
     @Before
     fun setUp() {
-        outputDir = temporaryFolder.newFolder()
-        brClassGenerator = DefaultBrClassGenerator(outputDir)
+        baseDir = temporaryFolder.newFolder()
+        brClassGenerator = DefaultBrClassGenerator(baseDir)
         val className = ClassName.get(DefaultBrClassGeneratorTest::class.java)
         layoutBinding = LayoutBindingData(
             layoutName = "SimpleBinding",
@@ -71,23 +70,23 @@ class DefaultBrClassGeneratorTest : BaseBindingStubTest() {
 
     @Test
     fun `assert BR class fields are derived from layout data expressions`() {
-        brClassGenerator.generate(packageName, listOf(layoutBinding))
+        val output = brClassGenerator.generate(packageName, listOf(layoutBinding))
         assertTrue {
-            generatedFileContents.contains("public static int _all = 0;")
+            generatedFileContents(output).contains("public static int _all = 0;")
         }
         assertTrue {
-            generatedFileContents.contains("public static int bindableName = 0;")
+            generatedFileContents(output).contains("public static int bindableName = 0;")
         }
         assertTrue {
-            generatedFileContents.contains("public static int userscore_name = 0;")
+            generatedFileContents(output).contains("public static int userscore_name = 0;")
         }
     }
 
     @Test
     fun `assert BR class fields does not have duplicates`() {
-        brClassGenerator.generate(packageName, listOf(layoutBinding))
+        val output = brClassGenerator.generate(packageName, listOf(layoutBinding))
         assertTrue {
-            generatedFileContents
+            generatedFileContents(output)
                 .lineSequence()
                 .map { it.trim() }
                 .count { it == "public static int userscore_name = 0;" } == 1


### PR DESCRIPTION
Continuing from https://github.com/grab/grab-bazel-common/pull/37, this PR implements worker/multiplex-worker support for the stub generator actions. 

1. On the compiler side, cleaned up to write directly to paths provided from bazel
2. Since single process will be shared in multiplexing mode, `@Singleton` scope for the stub component did not feel right, hence introduced a new scope `@AaptScope`. Later we can rename the compiler to `MiniAapt` since it is doing more than databinding stub generation.

Fixes #5 