### PR TITLE
Disable header compilation for r-classes

### DIFF
--- a/tools/databinding/databinding.bzl
+++ b/tools/databinding/databinding.bzl
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load(":databinding_stubs.bzl", "databinding_stubs")
+load("@grab_bazel_common//tools/java:java_library_no_header.bzl", "java_library_no_header")
 # load(":databinding_aar.bzl", "databinding_aar")
 
 # TODO(arun) Replace with configurable maven targets
@@ -95,6 +96,12 @@ def kt_db_android_library(
         neverlink = 1,  # Use the R classes only for compiling and not at runtime.
     )
 
+    r_classes_no_header = name + "-r-classes-no-header"
+    java_library_no_header(
+        name = r_classes_no_header,
+        dep = ":" + r_classes,
+    )
+
     # Create an intermediate target for compiling all Kotlin classes used in Databinding
     kotlin_target = name + "-kotlin"
     kotlin_targets = []
@@ -114,7 +121,7 @@ def kt_db_android_library(
             name = kotlin_target,
             srcs = srcs + [binding_classes_sources],
             plugins = plugins,
-            deps = deps + _DATABINDING_DEPS + [r_classes] + [
+            deps = deps + _DATABINDING_DEPS + [r_classes_no_header] + [
                 "@grab_bazel_common//tools/binding-adapter-bridge:binding-adapter-bridge",
                 "@grab_bazel_common//tools/android:android_sdk",
             ],

--- a/tools/java/java_library_no_header.bzl
+++ b/tools/java/java_library_no_header.bzl
@@ -1,0 +1,26 @@
+def _java_header_compilation_transition(settings, attr):
+    _ignore = (settings, attr)
+    return {"//command_line_option:java_header_compilation": "False"}
+
+java_header_compilation_transition = transition(
+    implementation = _java_header_compilation_transition,
+    inputs = [],
+    outputs = ["//command_line_option:java_header_compilation"],
+)
+
+def _java_library_without_header_compilation(ctx):
+    return [java_common.merge([d[JavaInfo] for d in ctx.attr.dep])]
+
+java_library_no_header = rule(
+    implementation = _java_library_without_header_compilation,
+    attrs = {
+        "dep": attr.label(
+            providers = [JavaInfo],
+            mandatory = True,
+            cfg = java_header_compilation_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
- Even though we are generating header like `R.java` with stub values, by default `java_library` compiles it again twice, one in normal and in header mode. Header compilation is wasteful here since `r-classes` target is on the critical path in the databinding module. This change implements idea from https://github.com/bazelbuild/bazel/issues/12837#issuecomment-766155870 which provides a transition to disable headers on a per target basis. 
      -  This is needed until https://github.com/grab/grab-bazel-common/issues/35 is implemented.
- In build config generate `BuildConfig.kt` directly instead of generating a `srcjar` which has to be unpacked to compile.