### PR TITLE
Fix test package detection

### DIFF
--- a/tools/test/test.bzl
+++ b/tools/test/test.bzl
@@ -189,7 +189,8 @@ def _unique_test_packages(packages):
         if package not in unique_packages:
             not_in_unique_packages = True
             for unique_package in unique_packages:
-                if package.startswith(unique_package):
+                # ensure that package is not a subpackage of unique_package
+                if package.startswith("{}.".format(unique_package)):
                     not_in_unique_packages = False
                     break
 


### PR DESCRIPTION
#34 Improves on the test package detection by allowing a list of test packages. This detection seems to not account to situations where packages are named `com.example.test` and `com.example.testing`. This results to only `com.example.test` getting created into `TestPackageName` class.

This PR fixes this problem by ensuring that the subpackage checks are inclusive of the period `.` in the package name