### PR TITLE
Update TestSuite detection to detect junit.framework.Test interface

### DIFF
--- a/tools/test-suite/src/main/java/com/grab/test/TestSuiteBuilder.kt
+++ b/tools/test-suite/src/main/java/com/grab/test/TestSuiteBuilder.kt
@@ -114,7 +114,10 @@ class TestSuiteBuilder {
                                 .annotationClass
                                 .qualifiedName == "org.junit.Test"
                         }
-                }
+                } || (container.superclass?.interfaces?.any {
+                    it.name == "junit.framework.Test"
+                } == true)
+
             } catch (e: ClassNotFoundException) {
                 false
             } catch (e: NoClassDefFoundError) {


### PR DESCRIPTION
The TestSuiteBuilder is currently only detecting `@Test` annotation on methods. 
It is also possible to be extending the `junit.framework.TestCase` class for test to be executed without the `@Test` annotation.