### PR TITLE
Generate stub for `DatabindingMapperImpl` to completely disable databinding annotation processor in header compilation

### DIFF
--- a/tools/android/BUILD.bazel
+++ b/tools/android/BUILD.bazel
@@ -1,6 +1,6 @@
 java_plugin(
     name = "compiler_annotation_processor",
-    generates_api = True,
+    generates_api = False,
     processor_class = "android.databinding.annotationprocessor.ProcessDataBinding",
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/generator/BindingClassGenerator.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/generator/BindingClassGenerator.kt
@@ -21,6 +21,7 @@ import com.grab.databinding.stub.binding.parser.Binding
 import com.grab.databinding.stub.binding.parser.BindingType
 import com.grab.databinding.stub.binding.parser.LayoutBindingData
 import com.grab.databinding.stub.common.BASE_DIR
+import com.grab.databinding.stub.common.DATABINDING_PACKAGE
 import com.grab.databinding.stub.common.Generator
 import com.grab.databinding.stub.util.capitalize
 import com.squareup.javapoet.*
@@ -54,7 +55,6 @@ constructor(
         private const val ATTACH_TO_ROOT = "attachToRoot"
         private const val COMPONENT = "component"
         private const val RUNTIME_EXCEPTION = """throw new RuntimeException("Stub!")"""
-        private const val DATABINDING_PACKAGE = "androidx.databinding"
         private const val VIEW_PACKAGE = "android.view"
     }
 
@@ -64,7 +64,6 @@ constructor(
     private val layoutInflaterClass = ClassName.get(VIEW_PACKAGE, "LayoutInflater")
     private val androidNonNull = ClassName.get("androidx.annotation", "NonNull")
     private val androidNullable = ClassName.get("androidx.annotation", "Nullable")
-    private val dataBindingComponent = ClassName.get(DATABINDING_PACKAGE, "DataBindingComponent")
     private val bindableAnnotation = ClassName.get(DATABINDING_PACKAGE, "Bindable")
     private val viewDataBinding = ClassName.get(DATABINDING_PACKAGE, "ViewDataBinding")
     private val emptyBinding = LayoutBindingData(
@@ -146,18 +145,6 @@ constructor(
                     }
             }
         return outputDir
-    }
-
-    private fun generateDataBindingComponentInterface(outputDir: File) {
-        TypeSpec.interfaceBuilder(dataBindingComponent)
-            .addModifiers(PUBLIC)
-            .build()
-            .let { type ->
-                JavaFile.builder(DATABINDING_PACKAGE, type)
-                    .build()
-                    .writeTo(outputDir)
-                logFile(DATABINDING_PACKAGE, type.name)
-            }
     }
 
     private fun buildFields(bindings: List<Binding>, bindables: List<Binding>): List<FieldSpec> {

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/generator/DatabiningComponent.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/binding/generator/DatabiningComponent.kt
@@ -1,0 +1,21 @@
+package com.grab.databinding.stub.binding.generator
+
+import com.grab.databinding.stub.common.DATABINDING_PACKAGE
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.TypeSpec
+import java.io.File
+import javax.lang.model.element.Modifier
+
+private val DatabindingComponent = ClassName.get(DATABINDING_PACKAGE, "DataBindingComponent")
+
+fun generateDataBindingComponentInterface(outputDir: File) {
+    TypeSpec.interfaceBuilder(DatabindingComponent)
+        .addModifiers(Modifier.PUBLIC)
+        .build()
+        .let { type ->
+            JavaFile.builder(DATABINDING_PACKAGE, type)
+                .build()
+                .writeTo(outputDir)
+        }
+}

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/Constants.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/common/Constants.kt
@@ -27,3 +27,6 @@ const val CLASS_INFOS = "CLASS_INFO"
 const val R_TXTS = "R_TXT_ZIP"
 
 const val NON_TRANSITIVE_R = "NON_TRANSITIVE_R"
+
+
+const val DATABINDING_PACKAGE = "androidx.databinding"

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/main.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/main.kt
@@ -16,13 +16,31 @@
 
 package com.grab.databinding.stub
 
+import com.grab.databinding.stub.mapper.GenerateMapperCommand
 import io.bazel.Status
 import io.bazel.Worker
+
+
+enum class Tool {
+    AAPT_LITE {
+        override fun call(args: Array<String>) {
+            BindingStubCommand().main(args)
+        }
+    },
+    DATABINDING_MAPPER {
+        override fun call(args: Array<String>) {
+            GenerateMapperCommand().main(args)
+        }
+    };
+
+    abstract fun call(args: Array<String>)
+}
 
 fun main(args: Array<String>) {
     Worker.from(args = args.toList()).run { cliArgs ->
         try {
-            BindingStubCommand().main(cliArgs)
+            Tool.valueOf(cliArgs.first())
+                .call(cliArgs.drop(1).toTypedArray())
             Status.Success
         } catch (e: Exception) {
             e.printStackTrace()

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/mapper/GenerateDatabindingMapper.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/mapper/GenerateDatabindingMapper.kt
@@ -1,0 +1,90 @@
+package com.grab.databinding.stub.mapper
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.grab.databinding.stub.binding.generator.generateDataBindingComponentInterface
+import java.io.File
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+private val MAPPER_FILE_TEMPLATE = """
+    package %s;
+    
+    import android.util.SparseArray;
+    import android.util.SparseIntArray;
+    import android.view.View;
+
+    import androidx.databinding.DataBinderMapper;
+    import androidx.databinding.DataBindingComponent;
+    import androidx.databinding.ViewDataBinding;
+
+    import java.util.ArrayList;
+    import java.util.HashMap;
+    import java.util.List;
+
+    public class DataBinderMapperImpl extends DataBinderMapper {
+
+        @Override
+        public ViewDataBinding getDataBinder(DataBindingComponent component, View view, int layoutId) {
+            return null;
+        }
+
+        @Override
+        public ViewDataBinding getDataBinder(DataBindingComponent component, View[] views, int layoutId) {
+            return null;
+        }
+
+        @Override
+        public int getLayoutId(String tag) {
+            return 0;
+        }
+
+        @Override
+        public String convertBrIdToString(int localId) {
+            return null;
+        }
+    }
+""".trimIndent()
+
+
+class GenerateMapperCommand : CliktCommand() {
+
+    private val packageName by option(
+        "-p",
+        "--package",
+        help = "Package name of R class"
+    ).required()
+
+    private val output by option(
+        "-o",
+        "--output",
+        help = "The mapper.srcjar file containing generated DatabindingMapper file"
+    ).convert { File(it) }.required()
+
+    private fun generateDatabindingMapper(dir: Path) {
+        val packageDir = dir.resolve(packageName.replace(".", File.separator))
+        Files.createDirectories(packageDir)
+        val outputPath = packageDir.resolve("DataBinderMapperImpl.java")
+        OutputStreamWriter(
+            Files.newOutputStream(outputPath),
+            StandardCharsets.UTF_8
+        ).use { writer ->
+            writer.write(MAPPER_FILE_TEMPLATE.format(packageName))
+        }
+    }
+
+    override fun run() {
+        val tmpDir = Files.createTempDirectory("tmp")
+        generateDatabindingMapper(tmpDir)
+        generateDataBindingComponentInterface(tmpDir.toFile())
+        val packager = DaggerMapperComponent.create().srcJarPackager
+        packager.packageSrcJar(
+            inputDir = tmpDir.toFile(),
+            outputFile = output
+        )
+    }
+}

--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/mapper/MapperComponent.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/mapper/MapperComponent.kt
@@ -1,0 +1,16 @@
+package com.grab.databinding.stub.mapper
+
+import com.grab.databinding.stub.AaptScope
+import com.grab.databinding.stub.common.SrcJarPackageModule
+import com.grab.databinding.stub.common.SrcJarPackager
+import dagger.Component
+
+@AaptScope
+@Component(
+    modules = [
+        SrcJarPackageModule::class
+    ]
+)
+interface MapperComponent {
+    val srcJarPackager: SrcJarPackager
+}

--- a/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/mapper/GenerateDatabindingMapperTest.kt
+++ b/tools/db-compiler-lite/src/test/java/com/grab/databinding/stub/mapper/GenerateDatabindingMapperTest.kt
@@ -1,0 +1,78 @@
+package com.grab.databinding.stub.mapper
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.zip.ZipFile
+import kotlin.test.assertTrue
+
+class GenerateDatabindingMapperTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `assert databinding mapper generated with package name`() {
+        val output = temporaryFolder.newFile("output.srcjar")
+        GenerateMapperCommand().main(
+            arrayOf(
+                "--package",
+                "com.grab",
+                "--output",
+                output.absolutePath
+            )
+        )
+        extractDatabindingMapper(output).readText().let { generatedContent ->
+            generatedContent.contains("")
+            assertTrue("Package name set") {
+                generatedContent.contains("package com.grab;")
+            }
+            assertTrue("getDataBinder 1 generated") {
+                generatedContent.contains(
+                    """    @Override
+    public ViewDataBinding getDataBinder(DataBindingComponent component, View view, int layoutId) {
+        return null;
+    }"""
+                )
+            }
+            assertTrue("getDataBinder 2 generated") {
+                generatedContent.contains(
+                    """    @Override
+    public ViewDataBinding getDataBinder(DataBindingComponent component, View[] views, int layoutId) {
+        return null;
+    }"""
+                )
+            }
+            assertTrue("getLayoutId generated") {
+                generatedContent.contains(
+                    """    @Override
+    public int getLayoutId(String tag) {
+        return 0;
+    }"""
+                )
+            }
+            assertTrue("convertBrIdToString generated") {
+                generatedContent.contains(
+                    """    @Override
+    public String convertBrIdToString(int localId) {
+        return null;
+    }"""
+                )
+            }
+        }
+    }
+
+    private fun extractDatabindingMapper(outputJar: File?): File {
+        ZipFile(outputJar).use { zip ->
+            val mapper = zip.entries()
+                .asSequence()
+                .filter { it.name.contains("DataBinderMapperImpl.java") }
+                .firstOrNull() ?: error("DataBinderMapperImpl was not generated")
+            zip.getInputStream(mapper).buffered().use { input ->
+                val extractedFile = temporaryFolder.newFile("DataBinderMapperImpl")
+                extractedFile.writeText(input.reader().readText())
+                return extractedFile
+            }
+        }
+    }
+}


### PR DESCRIPTION
Header compilation is nice but that also means annotation processors are run twice per module. Databinding is already slow + consumes transitive R.txts + some databinding artifacts which affects overall parallelism. This change generates `DatabindingMapperImpl` for a module so that that public ABI of a module is fully complete (we already generate other stubs).

This way by setting `generates_api` to `False` in `java_plugin`, we can avoid running `ProcessDatabinding` twice.

This change generates a dummy `DatabindingMapperImpl` and puts it on the compile classpath alone to let header compilation succeed. There is overhead in compiling `DatabindingMapperImpl`, yes but that is worth it since it is lot less work compared to what databinding would do. 

Seeing 15% improvement in a small project but impact is expected to be higher in large apps with lot of depth in the graph.
