### PR TITLE
Refactor dependencies and split tooling and runtime classpath via separate `maven_install`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,8 @@
-load("@dagger//:workspace_defs.bzl", "dagger_rules")
+load("@bazel_common_dagger//:workspace_defs.bzl", "dagger_rules")
 
-dagger_rules()
+dagger_rules(
+    repo_name = "@bazel_common_maven",
+)
 
 load("@grab_bazel_common//toolchains:toolchains.bzl", "configure_toolchains")
 

--- a/README.md
+++ b/README.md
@@ -15,28 +15,18 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "grab_bazel_common",
-    commit = "<commit-hash>",
+    commit = "<commit hash>",
     remote = "https://github.com/grab/grab-bazel-common.git",
 )
 
-# Optional patched Android Tools
-load("@grab_bazel_common//:workspace_defs.bzl", "android_tools")
+load("@grab_bazel_common//android:repositories.bzl", "bazel_common_dependencies")
 
-android_tools(
-    commit = "<commit-hash>",
-    remote = "https://github.com/grab/grab-bazel-common.git",
-)
+bazel_common_dependencies()
 
-# Maven dependencies
-load("@grab_bazel_common//:workspace_defs.bzl", "GRAB_BAZEL_COMMON_ARTIFACTS")
+load("@grab_bazel_common//android:initialize.bzl", "bazel_common_initialize")
 
-load("@rules_jvm_external//:defs.bzl", "maven_install")
-
-maven_install(
-    artifacts = GRAB_BAZEL_COMMON_ARTIFACTS + [
-        # ... 
-    ],
-    ...
+bazel_common_initialize(
+    buildifier_version = "5.1.0",
 )
 ```
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,94 +1,14 @@
 workspace(name = "grab_bazel_common")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@grab_bazel_common//android:repositories.bzl", "bazel_common_dependencies")
 
-# http_archive(
-#     name = "com_google_protobuf",
-#     sha256 = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
-#     strip_prefix = "protobuf-%s" % "3.11.3",
-#     urls = [
-#         "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % "3.11.3",
-#         "https://github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % "3.11.3",
-#     ],
-# )
+bazel_common_dependencies()
 
-# http_archive(
-#     name = "bazel_skylib",
-#     sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-#     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/%s/bazel-skylib-%s.tar.gz" % (
-#         "1.0.3",
-#         "1.0.3",
-#     )],
-# )
+load("@grab_bazel_common//android:initialize.bzl", "bazel_common_initialize")
 
-# http_archive(
-#     name = "rules_proto",
-#     sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
-#     strip_prefix = "rules_proto-4.0.0-3.20.0",
-#     urls = [
-#         "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
-#     ],
-# )
-
-# load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
-# rules_proto_dependencies()
-
-# rules_proto_toolchains()
-
-RULES_JVM_EXTERNAL_TAG = "3.3"
-
-RULES_JVM_EXTERNAL_SHA = "d85951a92c0908c80bd8551002d66cb23c3434409c814179c0ff026b53544dab"
-
-http_archive(
-    name = "rules_jvm_external",
-    sha256 = RULES_JVM_EXTERNAL_SHA,
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
-)
-
-DAGGER_TAG = "2.37"
-
-DAGGER_SHA = "0f001ed38ed4ebc6f5c501c20bd35a68daf01c8dbd7541b33b7591a84fcc7b1c"
-
-http_archive(
-    name = "dagger",
-    sha256 = DAGGER_SHA,
-    strip_prefix = "dagger-dagger-%s" % DAGGER_TAG,
-    url = "https://github.com/google/dagger/archive/dagger-%s.zip" % DAGGER_TAG,
-)
-
-load("@dagger//:workspace_defs.bzl", "DAGGER_ARTIFACTS", "DAGGER_REPOSITORIES")
-load("@//:workspace_defs.bzl", "GRAB_BAZEL_COMMON_ARTIFACTS")
-load("@rules_jvm_external//:defs.bzl", "maven_install")
-
-maven_install(
-    artifacts = DAGGER_ARTIFACTS + GRAB_BAZEL_COMMON_ARTIFACTS + [
-        "androidx.databinding:databinding-adapters:3.4.2",
-        "androidx.databinding:databinding-common:3.4.2",
-        "androidx.databinding:databinding-runtime:3.4.2",
-        "androidx.annotation:annotation:1.1.0",
-        "com.github.tschuchortdev:kotlin-compile-testing:1.3.1",
-        "com.google.android.material:material:1.2.1",
-        "javax.inject:javax.inject:1",
-        "junit:junit:4.13",
-        "org.json:json:20210307",
-    ],
-    repositories = DAGGER_REPOSITORIES + [
-        "https://jcenter.bintray.com/",
-        "https://maven.google.com",
-    ],
-    strict_visibility = True,
-)
-
-RULES_KOTLIN_VERSION = "1.6.0-RC-2"
-
-RULES_KOTLIN_SHA = "88d19c92a1fb63fb64ddb278cd867349c3b0d648b6fe9ef9a200b9abcacd489d"
-
-http_archive(
-    name = "io_bazel_rules_kotlin",
-    sha256 = RULES_KOTLIN_SHA,
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
+bazel_common_initialize(
+    buildifier_version = "5.1.0",
 )
 
 load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
@@ -103,14 +23,16 @@ android_sdk_repository(
     name = "androidsdk",
 )
 
-load("@grab_bazel_common//:workspace_defs.bzl", "ANDROID_TOOLS_BUILD_FILE")
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@grab_bazel_common//:workspace_defs.bzl", "GRAB_BAZEL_COMMON_ARTIFACTS")
 
-new_local_repository(
-    name = "android_tools",
-    build_file_content = ANDROID_TOOLS_BUILD_FILE,
-    path = ".",
+# Artifacts that need to be present on the consumer under @maven. They can be overriden
+# by the consumer's maven_install rule.
+maven_install(
+    artifacts = GRAB_BAZEL_COMMON_ARTIFACTS,
+    repositories = [
+        "https://jcenter.bintray.com/",
+        "https://maven.google.com",
+    ],
+    strict_visibility = True,
 )
-
-load("@grab_bazel_common//toolchains:toolchains.bzl", "register_common_toolchains")
-
-register_common_toolchains()

--- a/android/initialize.bzl
+++ b/android/initialize.bzl
@@ -1,0 +1,47 @@
+load("@bazel_common_dagger//:workspace_defs.bzl", "DAGGER_ARTIFACTS", "DAGGER_REPOSITORIES")
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@grab_bazel_common//toolchains:toolchains.bzl", "register_common_toolchains", _buildifier_version = "buildifier_version")
+load("@grab_bazel_common//:workspace_defs.bzl", "GRAB_BAZEL_COMMON_ARTIFACTS")
+load("@grab_bazel_common//tools/buildifier:defs.bzl", "BUILDIFIER_DEFAULT_VERSION")
+# load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+def bazel_common_initialize(
+        buildifier_version = BUILDIFIER_DEFAULT_VERSION):
+    #rules_proto_dependencies()
+    #rules_proto_toolchains()
+
+    register_common_toolchains(
+        buildifier = _buildifier_version(
+            version = buildifier_version,
+        ),
+    )
+
+    maven_install(
+        name = "bazel_common_maven",
+        artifacts = DAGGER_ARTIFACTS + [
+            "com.google.guava:guava:29.0-jre",
+            "com.google.auto:auto-common:0.10",
+            "com.google.auto.service:auto-service:1.0-rc6",
+            "com.google.protobuf:protobuf-java:3.6.0",
+            "com.google.protobuf:protobuf-java-util:3.6.0",
+            "com.squareup:javapoet:1.13.0",
+            "com.github.ajalt:clikt:2.8.0",
+            "org.ow2.asm:asm:6.0",
+            "org.ow2.asm:asm-tree:6.0",
+            "xmlpull:xmlpull:1.1.3.1",
+            "net.sf.kxml:kxml2:2.3.0",
+            "com.squareup.moshi:moshi:1.11.0",
+            "org.jetbrains.kotlin:kotlin-parcelize-compiler:1.6.10",
+            "org.jetbrains.kotlin:kotlin-parcelize-runtime:1.6.10",
+            "com.github.tschuchortdev:kotlin-compile-testing:1.3.1",
+            "com.google.android.material:material:1.2.1",
+            "javax.inject:javax.inject:1",
+            "junit:junit:4.13",
+            "org.json:json:20210307",
+        ],
+        repositories = DAGGER_REPOSITORIES + [
+            "https://jcenter.bintray.com/",
+            "https://maven.google.com",
+        ],
+        strict_visibility = True,
+    )

--- a/android/repositories.bzl
+++ b/android/repositories.bzl
@@ -1,0 +1,82 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@grab_bazel_common//:workspace_defs.bzl", "ANDROID_TOOLS_BUILD_FILE")
+
+def http_archive(name, **kwargs):
+    maybe(_http_archive, name = name, **kwargs)
+
+def _maven():
+    RULES_JVM_EXTERNAL_TAG = "3.3"
+    RULES_JVM_EXTERNAL_SHA = "d85951a92c0908c80bd8551002d66cb23c3434409c814179c0ff026b53544dab"
+
+    http_archive(
+        name = "rules_jvm_external",
+        sha256 = RULES_JVM_EXTERNAL_SHA,
+        strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+    )
+
+    DAGGER_TAG = "2.37"
+
+    DAGGER_SHA = "0f001ed38ed4ebc6f5c501c20bd35a68daf01c8dbd7541b33b7591a84fcc7b1c"
+
+    http_archive(
+        name = "bazel_common_dagger",
+        sha256 = DAGGER_SHA,
+        strip_prefix = "dagger-dagger-%s" % DAGGER_TAG,
+        url = "https://github.com/google/dagger/archive/dagger-%s.zip" % DAGGER_TAG,
+    )
+
+def _android():
+    maybe(
+        native.new_local_repository,
+        name = "android_tools",
+        build_file_content = ANDROID_TOOLS_BUILD_FILE,
+        path = ".",
+    )
+
+def _kotlin():
+    RULES_KOTLIN_VERSION = "1.6.0-RC-2"
+
+    RULES_KOTLIN_SHA = "88d19c92a1fb63fb64ddb278cd867349c3b0d648b6fe9ef9a200b9abcacd489d"
+
+    http_archive(
+        name = "io_bazel_rules_kotlin",
+        sha256 = RULES_KOTLIN_SHA,
+        urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
+    )
+
+def _proto():
+    http_archive(
+        name = "com_google_protobuf",
+        sha256 = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
+        strip_prefix = "protobuf-%s" % "3.11.3",
+        urls = [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % "3.11.3",
+            "https://github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % "3.11.3",
+        ],
+    )
+
+    http_archive(
+        name = "bazel_skylib",
+        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/%s/bazel-skylib-%s.tar.gz" % (
+            "1.0.3",
+            "1.0.3",
+        )],
+    )
+
+    http_archive(
+        name = "rules_proto",
+        sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
+        strip_prefix = "rules_proto-4.0.0-3.20.0",
+        urls = [
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
+        ],
+    )
+
+def bazel_common_dependencies():
+    #_proto
+    _maven()
+    _android()
+    _kotlin()

--- a/tools/android-mock/BUILD.bazel
+++ b/tools/android-mock/BUILD.bazel
@@ -9,10 +9,10 @@ kt_jvm_library(
         "//visibility:private",
     ],
     deps = [
+        "@bazel_common_maven//:com_github_ajalt_clikt",
+        "@bazel_common_maven//:org_ow2_asm_asm",
+        "@bazel_common_maven//:org_ow2_asm_asm_tree",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
-        "@maven//:com_github_ajalt_clikt",
-        "@maven//:org_ow2_asm_asm",
-        "@maven//:org_ow2_asm_asm_tree",
     ],
 )
 

--- a/tools/auto-service/BUILD.bazel
+++ b/tools/auto-service/BUILD.bazel
@@ -2,7 +2,7 @@ java_plugin(
     name = "auto-service-plugin",
     processor_class = "com.google.auto.service.processor.AutoServiceProcessor",
     deps = [
-        "@maven//:com_google_auto_service_auto_service",
+        "@bazel_common_maven//:com_google_auto_service_auto_service",
     ],
 )
 
@@ -11,6 +11,6 @@ java_library(
     exported_plugins = [":auto-service-plugin"],
     visibility = ["//visibility:public"],
     exports = [
-        "@maven//:com_google_auto_service_auto_service",
+        "@bazel_common_maven//:com_google_auto_service_auto_service",
     ],
 )

--- a/tools/binding-adapter-bridge/BUILD.bazel
+++ b/tools/binding-adapter-bridge/BUILD.bazel
@@ -8,12 +8,12 @@ kt_jvm_library(
     ]),
     deps = [
         "//tools/auto-service",
+        "@bazel_common_maven//:com_google_auto_auto_common",
+        "@bazel_common_maven//:com_google_auto_service_auto_service",
+        "@bazel_common_maven//:com_google_guava_guava",
+        "@bazel_common_maven//:com_squareup_javapoet",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
         "@maven//:androidx_databinding_databinding_adapters",
-        "@maven//:com_google_auto_auto_common",
-        "@maven//:com_google_auto_service_auto_service",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_squareup_javapoet",
     ],
 )
 
@@ -23,8 +23,8 @@ java_plugin(
     processor_class = "com.grab.pax.binding.processor.BindingAdapterProcessor",
     deps = [
         ":binding-adapter-processor",
+        "@bazel_common_maven//:com_google_auto_service_auto_service",
         "@maven//:androidx_databinding_databinding_adapters",
-        "@maven//:com_google_auto_service_auto_service",
     ],
 )
 
@@ -45,8 +45,8 @@ grab_kt_jvm_test(
     deps = [
         ":binding-adapter-bridge",
         ":binding-adapter-processor",
+        "@bazel_common_maven//:com_github_tschuchortdev_kotlin_compile_testing",
+        "@bazel_common_maven//:junit_junit",
         "@com_github_jetbrains_kotlin//:kotlin-test",
-        "@maven//:com_github_tschuchortdev_kotlin_compile_testing",
-        "@maven//:junit_junit",
     ],
 )

--- a/tools/db-compiler-lite/BUILD
+++ b/tools/db-compiler-lite/BUILD
@@ -12,13 +12,13 @@ kt_jvm_library(
     deps = [
         "//:dagger",
         "//tools/worker:worker_lib",
+        "@bazel_common_maven//:com_github_ajalt_clikt",
+        "@bazel_common_maven//:com_squareup_javapoet",
+        "@bazel_common_maven//:com_squareup_moshi_moshi",
+        "@bazel_common_maven//:net_sf_kxml_kxml2",
+        "@bazel_common_maven//:xmlpull_xmlpull",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
         "@maven//:androidx_databinding_databinding_common",
-        "@maven//:com_github_ajalt_clikt",
-        "@maven//:com_squareup_javapoet",
-        "@maven//:com_squareup_moshi_moshi",
-        "@maven//:net_sf_kxml_kxml2",
-        "@maven//:xmlpull_xmlpull",
     ],
 )
 
@@ -29,8 +29,8 @@ grab_kt_jvm_test(
     ]),
     deps = [
         ":db-compiler-lite-lib",
+        "@bazel_common_maven//:junit_junit",
         "@com_github_jetbrains_kotlin//:kotlin-test",
-        "@maven//:junit_junit",
     ],
 )
 

--- a/tools/test-suite-generator/BUILD.bazel
+++ b/tools/test-suite-generator/BUILD.bazel
@@ -7,10 +7,10 @@ kt_jvm_library(
     ]),
     deps = [
         "//tools/auto-service",
-        "@maven//:com_google_auto_auto_common",
-        "@maven//:com_google_auto_service_auto_service",
-        "@maven//:com_squareup_javapoet",
-        "@maven//:junit_junit",
+        "@bazel_common_maven//:com_google_auto_auto_common",
+        "@bazel_common_maven//:com_google_auto_service_auto_service",
+        "@bazel_common_maven//:com_squareup_javapoet",
+        "@bazel_common_maven//:junit_junit",
     ],
 )
 
@@ -38,7 +38,7 @@ kt_jvm_test(
     test_class = "com.grazel.generated.TestSuite",
     deps = [
         ":test-suite-generator",
+        "@bazel_common_maven//:junit_junit",
         "@com_github_jetbrains_kotlin//:kotlin-test",
-        "@maven//:junit_junit",
     ],
 )

--- a/tools/test-suite/BUILD.bazel
+++ b/tools/test-suite/BUILD.bazel
@@ -9,7 +9,7 @@ kt_jvm_library(
         "//visibility:public",
     ],
     deps = [
-        "@maven//:com_google_guava_guava",
-        "@maven//:junit_junit",
+        "@bazel_common_maven//:com_google_guava_guava",
+        "@bazel_common_maven//:junit_junit",
     ],
 )

--- a/tools/test/android/BUILD.bazel
+++ b/tools/test/android/BUILD.bazel
@@ -7,7 +7,7 @@ kt_android_library(
         "src/main/java/**/*.kt",
     ]),
     deps = [
-        "@maven//:com_google_android_material_material",
+        "@bazel_common_maven//:com_google_android_material_material",
     ],
 )
 

--- a/tools/worker/BUILD.bazel
+++ b/tools/worker/BUILD.bazel
@@ -12,8 +12,8 @@ kt_jvm_library(
     ],
     deps = [
         "//tools/worker/src/main/proto:worker_protocol",
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@bazel_common_maven//:com_google_protobuf_protobuf_java",
+        "@bazel_common_maven//:com_google_protobuf_protobuf_java_util",
     ],
 )
 
@@ -24,7 +24,7 @@ grab_kt_jvm_test(
     ]),
     deps = [
         ":worker_lib",
+        "@bazel_common_maven//:junit_junit",
         "@com_github_jetbrains_kotlin//:kotlin-test",
-        "@maven//:junit_junit",
     ],
 )

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -1,20 +1,14 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 GRAB_BAZEL_COMMON_ARTIFACTS = [
-    "com.google.guava:guava:29.0-jre",
-    "com.google.auto:auto-common:0.10",
-    "com.google.auto.service:auto-service:1.0-rc6",
-    "com.google.protobuf:protobuf-java:3.6.0",
-    "com.google.protobuf:protobuf-java-util:3.6.0",
-    "com.squareup:javapoet:1.13.0",
-    "com.github.ajalt:clikt:2.8.0",
-    "org.ow2.asm:asm:6.0",
-    "org.ow2.asm:asm-tree:6.0",
-    "xmlpull:xmlpull:1.1.3.1",
-    "net.sf.kxml:kxml2:2.3.0",
-    "com.squareup.moshi:moshi:1.11.0",
     "org.jetbrains.kotlin:kotlin-parcelize-compiler:1.6.10",
     "org.jetbrains.kotlin:kotlin-parcelize-runtime:1.6.10",
+    "androidx.databinding:databinding-adapters:7.1.2",
+    "androidx.databinding:databinding-common:7.1.2",
+    "androidx.databinding:databinding-runtime:7.1.2",
+    "androidx.databinding:viewbinding:7.1.2",
+    "org.json:json:20210307",
+    "junit:junit:4.13",
 ]
 
 ANDROID_TOOLS_BUILD_FILE = """
@@ -27,8 +21,8 @@ exports_files([
 
 def android_tools(commit, remote, **kwargs):
     """
-    Register a @android_tools repository used for databinding that overrides the official @android_tools repository with precompiled
-    android tools' library jars
+    Register a @android_tools repository used for databinding that overrides the official @android_tools
+    repository with precompiled android tools' library jars
 
     Args:
       Provide typical arguments that would be provided to new_git_repository.


### PR DESCRIPTION
Fixes #28

Bazel common tooling targets now use `bazel_common_maven` and targets that need to be present in the consumer runtime alone are added via `GRAB_BAZEL_COMMON_ARTIFACTS`. After this change, tooling updates in bazel common should not affect app runtime behavior which was the case before. Versions specified in `GRAB_BAZEL_COMMON_ARTIFACTS` can also be overriden by consuming project's versions as expected.

This also changes how bazel common is imported into consuming project via new WORKSPACE macros. Same changes are required on Grazel which will follow.