### PR TITLE
Add R type for navigation

### DIFF
--- a/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/RTxtParser.kt
+++ b/tools/db-compiler-lite/src/main/java/com/grab/databinding/stub/rclass/parser/RTxtParser.kt
@@ -48,6 +48,7 @@ enum class Type(val entry: String) {
     LAYOUT("layout"),
     MENU("menu"),
     MIPMAP("mipmap"),
+    NAVIGATION("navigation"),
     PLURALS("plurals"),
     RAW("raw"),
     STRING("string"),


### PR DESCRIPTION
It isn't part of the spec, but this type is used in androidx.navigation. Without this, modules using androidx.navigation won't build.

(Feel free to reject if you aren't interested in supporting this as a use case; it's easy enough to keep as a fork.)