### PR TITLE
Fix parcelize deps to bazel_common_maven

### DIFF
--- a/android/initialize.bzl
+++ b/android/initialize.bzl
@@ -3,7 +3,6 @@ load(
     "register_common_toolchains",
     _buildifier_version = "buildifier_version",
 )
-load("@grab_bazel_common//:workspace_defs.bzl", "GRAB_BAZEL_COMMON_ARTIFACTS")
 load("@grab_bazel_common//tools/buildifier:defs.bzl", "BUILDIFIER_DEFAULT_VERSION")
 load("@grab_bazel_common//android/tools:defs.bzl", "android_tools")
 load("@bazel_common_dagger//:workspace_defs.bzl", "DAGGER_ARTIFACTS", "DAGGER_REPOSITORIES")

--- a/tools/parcelize/parcelize.bzl
+++ b/tools/parcelize/parcelize.bzl
@@ -27,7 +27,7 @@ def parcelize_rules():
         stubs_phase = False,
         target_embedded_compiler = True,
         deps = [
-            "@maven//:org_jetbrains_kotlin_kotlin_parcelize_compiler",
+            "@bazel_common_maven//:org_jetbrains_kotlin_kotlin_parcelize_compiler",
         ],
     )
 
@@ -36,6 +36,6 @@ def parcelize_rules():
         exported_compiler_plugins = [":parcelize_plugin"],
         visibility = ["//visibility:public"],
         exports = [
-            "@maven//:org_jetbrains_kotlin_kotlin_parcelize_runtime",
+            "@bazel_common_maven//:org_jetbrains_kotlin_kotlin_parcelize_runtime",
         ],
     )


### PR DESCRIPTION
In addition to #59 and #60, the parcelize dependencies should also be reading from the new bazel_common_maven