### PR TITLE
Implement build config generation with a dedicated tool and add worker support

### DIFF
--- a/tools/build_config/BUILD
+++ b/tools/build_config/BUILD
@@ -12,6 +12,13 @@ java_binary(
     ],
 )
 
+config_setting(
+    name = "build_config_alternative",
+    define_values = {
+        "alternate_values": "true",
+    },
+)
+
 build_config(
     name = "build-config-sample",
     package_name = "com.grab.buildconfig.sample",
@@ -32,6 +39,10 @@ build_config(
         "SPECIAL_CHARACTERS": "!@#$%^&*()$",
         "FIELD_WITH_ESCAPED_DOLLAR": "\\$ Hello",
         "REWARD_URL": "https://reward.com/hc/%1$s/test",
+        "SELECT": select({
+            ":build_config_alternative": ["alternate value"],
+            "//conditions:default": ["default value"],
+        }),
     },
 )
 

--- a/tools/build_config/BUILD
+++ b/tools/build_config/BUILD
@@ -1,6 +1,17 @@
 load(":build_config.bzl", "build_config")
 load("@grab_bazel_common//tools/test:test.bzl", "grab_kt_jvm_test")
 
+java_binary(
+    name = "build_config_generator",
+    main_class = "com.grab.buildconfig.MainKt",
+    visibility = [
+        "//visibility:public",
+    ],
+    runtime_deps = [
+        "//tools/build_config/src/main/java/com/grab/buildconfig",
+    ],
+)
+
 build_config(
     name = "build-config-sample",
     package_name = "com.grab.buildconfig.sample",

--- a/tools/build_config/build_config.bzl
+++ b/tools/build_config/build_config.bzl
@@ -72,7 +72,7 @@ def _build_config_generator_impl(ctx):
             output_directory,
             output,
         ],
-        executable = ctx.executable._compiler,
+        executable = ctx.executable._generator,
         arguments = [args],
         progress_message = "%s %s" % (mnemonic, ctx.label),
         execution_requirements = {
@@ -101,7 +101,7 @@ _build_config_generator = rule(
         "int_values": attr.string_list(),
         "long_keys": attr.string_list(),
         "long_values": attr.string_list(),
-        "_compiler": attr.label(
+        "_generator": attr.label(
             default = Label("@grab_bazel_common//tools/build_config:build_config_generator"),
             executable = True,
             cfg = "exec",

--- a/tools/build_config/build_config.bzl
+++ b/tools/build_config/build_config.bzl
@@ -50,7 +50,7 @@ def build_config(
         booleans = {},
         ints = {},
         longs = {}):
-    """Generates a java_library target containing build config fields just like AGP.
+    """Generates a kt_jvm_library target containing build config fields just like AGP.
 
     Usage:
     Add the field variables in the relevant dicts like (strings, booleans etc) and add a dependency

--- a/tools/build_config/build_config.bzl
+++ b/tools/build_config/build_config.bzl
@@ -4,9 +4,8 @@ _INT_TYPE = "ints"
 _LONG_TYPE = "longs"
 
 def _build_cmd_options(
-    flag,
-    value_dict = {},
-):
+        flag,
+        value_dict = {}):
     cmd_options = ""
     if len(value_dict) > 0:
         cmd_options += " --%s " % flag
@@ -19,7 +18,7 @@ def _build_cmd_options(
                 is_first = False
             else:
                 cmd_options += ",%s=" % key
-            
+
             if type(value) == "select":
                 cmd_options += value
             else:
@@ -34,8 +33,7 @@ def _build_cmd_options(
     return cmd_options
 
 def _generate_final_strings(
-    strings = {}
-):
+        strings = {}):
     if (strings.get("VERSION_NAME", default = None) == None):
         # If the VERSION_NAME is not available, we auto add a default version name
         return dict(strings, VERSION_NAME = "VERSION_NAME", BUILD_TYPE = "debug")
@@ -77,19 +75,19 @@ def build_config(
     )
 
     cmd += _build_cmd_options(
-        _STRING_TYPE, 
-        _generate_final_strings(strings)
+        _STRING_TYPE,
+        _generate_final_strings(strings),
     )
 
     dbg = "true" if debug else "false"
 
     cmd += _build_cmd_options(
-        _BOOLEAN_TYPE, 
-        dict(booleans, DEBUG = dbg)
+        _BOOLEAN_TYPE,
+        dict(booleans, DEBUG = dbg),
     )
     cmd += _build_cmd_options(_INT_TYPE, ints)
     cmd += _build_cmd_options(_LONG_TYPE, longs)
-    
+
     native.genrule(
         name = "_%s_gen" % name,
         outs = [build_config_file_path],
@@ -98,7 +96,7 @@ def build_config(
         tools = [build_config_generator],
         message = "Generating %s's build config class" % (native.package_name()),
     )
-    
+
     native.java_library(
         name = name,
         srcs = [build_config_file_path],

--- a/tools/build_config/build_config.bzl
+++ b/tools/build_config/build_config.bzl
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
 _STRING_TYPE = "strings"
 _BOOLEAN_TYPE = "booleans"
 _INT_TYPE = "ints"
@@ -97,7 +99,7 @@ def build_config(
         message = "Generating %s's build config class" % (native.package_name()),
     )
 
-    native.java_library(
+    kt_jvm_library(
         name = name,
         srcs = [build_config_file_path],
     )

--- a/tools/build_config/build_config.bzl
+++ b/tools/build_config/build_config.bzl
@@ -8,7 +8,7 @@ def _flatten_key_value_pair(keys = [], values = []):
             "{key}={value}".format(
                 key = key,
                 value = value,
-            )
+            ),
         )
 
     return result
@@ -37,22 +37,22 @@ def _build_config_generator_impl(ctx):
     args.add_joined(
         "--strings",
         strings,
-        join_with = ","
+        join_with = ",",
     )
     args.add_joined(
         "--booleans",
         booleans,
-        join_with = ","
+        join_with = ",",
     )
     args.add_joined(
         "--ints",
         ints,
-        join_with = ","
+        join_with = ",",
     )
     args.add_joined(
         "--longs",
         longs,
-        join_with = ","
+        join_with = ",",
     )
 
     output_directory = ctx.actions.declare_directory(ctx.label.name)
@@ -62,7 +62,7 @@ def _build_config_generator_impl(ctx):
         "{name}/{package_name}/BuildConfig.java".format(
             name = ctx.label.name,
             package_name = package_name.replace(".", "/"),
-        )
+        ),
     )
 
     mnemonic = "BuildConfigGeneration"
@@ -85,8 +85,8 @@ def _build_config_generator_impl(ctx):
 
     return [
         DefaultInfo(files = depset([
-            output
-        ]))
+            output,
+        ])),
     ]
 
 _build_config_generator = rule(
@@ -104,14 +104,14 @@ _build_config_generator = rule(
         "_compiler": attr.label(
             default = Label("@grab_bazel_common//tools/build_config:build_config_generator"),
             executable = True,
-            cfg = "exec"
+            cfg = "exec",
         ),
     },
 )
 
 def _convert_to_keys_values_tuple(dict = {}):
     """Converts the given dict into a tuple with a list of keys and a list of values.
-    
+
     Static values and dynamic (select()) values are being separated and finally
     combined with dynamic keys and values getting pushed to the back of the list
     """
@@ -122,7 +122,7 @@ def _convert_to_keys_values_tuple(dict = {}):
             dynamics[key] = value
         else:
             statics[key] = str(value)
-    
+
     keys = statics.keys() + dynamics.keys()
     values = statics.values()
     for dynamic_value in dynamics.values():
@@ -164,11 +164,11 @@ def build_config(
     dbg = "true" if debug else "false"
 
     (string_keys, string_values) = _convert_to_keys_values_tuple(
-        _generate_final_strings(strings)
+        _generate_final_strings(strings),
     )
 
     (boolean_keys, boolean_values) = _convert_to_keys_values_tuple(
-        dict(booleans, DEBUG = dbg)
+        dict(booleans, DEBUG = dbg),
     )
 
     (int_keys, int_values) = _convert_to_keys_values_tuple(ints)
@@ -190,5 +190,5 @@ def build_config(
 
     kt_jvm_library(
         name = name,
-        srcs = [build_config_target]
+        srcs = [build_config_target],
     )

--- a/tools/build_config/build_config.bzl
+++ b/tools/build_config/build_config.bzl
@@ -55,21 +55,18 @@ def _build_config_generator_impl(ctx):
         join_with = ",",
     )
 
-    output_directory = ctx.actions.declare_directory(ctx.label.name)
-    args.add("--output", output_directory.path)
-
     output = ctx.actions.declare_file(
         "{name}/{package_name}/BuildConfig.java".format(
             name = ctx.label.name,
             package_name = package_name.replace(".", "/"),
         ),
     )
+    args.add("--output", output)
 
     mnemonic = "BuildConfigGeneration"
     ctx.actions.run(
         mnemonic = mnemonic,
         outputs = [
-            output_directory,
             output,
         ],
         executable = ctx.executable._generator,
@@ -79,7 +76,7 @@ def _build_config_generator_impl(ctx):
             "supports-workers": "1",
             "supports-multiplex-workers": "1",
             "requires-worker-protocol": "json",
-            "worker-key-mnemonic": "BuildConfigGenerationWorker",
+            "worker-key-mnemonic": "%sWorker" % mnemonic,
         },
     )
 

--- a/tools/build_config/src/main/java/com/grab/buildconfig/BUILD.bazel
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "buildconfig",
+    srcs = glob([
+        "*.kt",
+    ]),
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//tools/worker:worker_lib",
+        "@bazel_common_maven//:com_github_ajalt_clikt",
+        "@bazel_common_maven//:com_squareup_javapoet",
+    ],
+)

--- a/tools/build_config/src/main/java/com/grab/buildconfig/BuildConfigGenerator.kt
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/BuildConfigGenerator.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2012-2023 Grab Taxi Holdings PTE LTD (GRAB), All Rights Reserved. NOTICE: All information contained herein is, and remains the property of GRAB. The intellectual and technical concepts contained herein are confidential, proprietary and controlled by GRAB and may be covered by patents, patents in process, and are protected by trade secret or copyright law.
+ * You are strictly forbidden to copy, download, store (in any medium), transmit, disseminate, adapt or change this material in any way unless prior written permission is obtained from GRAB. Access to the source code contained herein is hereby forbidden to anyone except current GRAB employees or contractors with binding Confidentiality and Non-disclosure agreements explicitly covering such access.
+ *
+ * The copyright notice above does not evidence any actual or intended publication or disclosure of this source code, which includes information that is confidential and/or proprietary, and is a trade secret, of GRAB.
+ * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC PERFORMANCE, OR PUBLIC DISPLAY OF OR THROUGH USE OF THIS SOURCE CODE WITHOUT THE EXPRESS WRITTEN CONSENT OF GRAB IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES. THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
+ */
+
+package com.grab.buildconfig
+
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.TypeName
+import com.squareup.javapoet.TypeSpec
+import java.io.File
+import java.lang.reflect.Type
+import javax.lang.model.element.Modifier
+
+class BuildConfigGenerator {
+
+    private fun String.toPair(): Pair<String, String> {
+        val keyValue = this.split("=")
+        return keyValue[0] to keyValue[1]
+    }
+
+    private fun String.toFieldSpec(
+        type: Type,
+        initializerFormat: String = "\$S",
+    ): FieldSpec = this
+        .toPair()
+        .let { (name, value) ->
+            FieldSpec
+                .builder(type, name)
+                .initialize(
+                    initializerFormat = initializerFormat,
+                    value = value,
+                )
+                .build()
+        }
+
+    private fun String.toFieldSpec(
+        type: TypeName,
+        initializerFormat: String = "\$L",
+    ): FieldSpec = this
+        .toPair()
+        .let { (name, value) ->
+            FieldSpec
+                .builder(type, name)
+                .initialize(
+                    initializerFormat = initializerFormat,
+                    value = value,
+                )
+                .build()
+        }
+
+    private fun FieldSpec.Builder.initialize(
+        value: String,
+        initializerFormat: String,
+    ): FieldSpec.Builder = this
+        .addModifiers(
+            Modifier.PUBLIC,
+            Modifier.STATIC,
+            Modifier.FINAL
+        )
+        .initializer(initializerFormat, value)
+
+    fun generate(
+        packageName: String,
+        output: File? = null,
+        strings: List<String>,
+        booleans: List<String>,
+        ints: List<String>,
+        longs: List<String>,
+    ) {
+        val stringFields = strings
+            .map { it.toFieldSpec(String::class.java) }
+
+        val booleanFields = booleans
+            .map {
+                it.toFieldSpec(
+                    type = TypeName.BOOLEAN,
+                    initializerFormat = "Boolean.parseBoolean(\$S)",
+                )
+            }
+
+        val intFields = ints
+            .map { it.toFieldSpec(TypeName.INT) }
+
+        val longFields = longs
+            .map {
+                it.toFieldSpec(
+                    type = TypeName.LONG,
+                    initializerFormat = "\$LL",
+                )
+            }
+
+        TypeSpec
+            .classBuilder("BuildConfig")
+            .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+            .addFields(stringFields)
+            .addFields(booleanFields)
+            .addFields(intFields)
+            .addFields(longFields)
+            .build()
+            .let { typeSpec ->
+                JavaFile
+                    .builder(packageName, typeSpec)
+                    .build()
+                    .apply {
+                        if (output != null) {
+                            writeTo(output)
+                        } else {
+                            writeTo(System.out)
+                        }
+                    }
+            }
+    }
+}

--- a/tools/build_config/src/main/java/com/grab/buildconfig/BuildConfigGenerator.kt
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/BuildConfigGenerator.kt
@@ -15,6 +15,7 @@ import com.squareup.javapoet.TypeSpec
 import java.io.File
 import java.lang.reflect.Type
 import javax.lang.model.element.Modifier
+import kotlin.io.path.createTempDirectory
 
 class BuildConfigGenerator {
 
@@ -66,7 +67,7 @@ class BuildConfigGenerator {
 
     fun generate(
         packageName: String,
-        output: File? = null,
+        output: File,
         strings: List<String>,
         booleans: List<String>,
         ints: List<String>,
@@ -106,12 +107,16 @@ class BuildConfigGenerator {
                 JavaFile
                     .builder(packageName, typeSpec)
                     .build()
+            }.let { javaFile ->
+                val outputDir = createTempDirectory()
+                javaFile.writeTo(outputDir)
+                return@let outputDir
+            }.apply {
+                toFile()
+                    .walkTopDown()
+                    .first { it.isFile }
                     .apply {
-                        if (output != null) {
-                            writeTo(output)
-                        } else {
-                            writeTo(System.out)
-                        }
+                        copyTo(output)
                     }
             }
     }

--- a/tools/build_config/src/main/java/com/grab/buildconfig/GeneratorCommand.kt
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/GeneratorCommand.kt
@@ -51,7 +51,8 @@ class GeneratorCommand : CliktCommand() {
     private val output by option(
         "-o",
         "--output",
-        help = "The output directory that the generated BuildConfig class will be written to",
+        help = "The output directory that the generated BuildConfig class will be written to. " +
+                "Will write to standard output if option not present",
     ).convert { File(it) }
 
     override fun run() {

--- a/tools/build_config/src/main/java/com/grab/buildconfig/GeneratorCommand.kt
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/GeneratorCommand.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2012-2023 Grab Taxi Holdings PTE LTD (GRAB), All Rights Reserved. NOTICE: All information contained herein is, and remains the property of GRAB. The intellectual and technical concepts contained herein are confidential, proprietary and controlled by GRAB and may be covered by patents, patents in process, and are protected by trade secret or copyright law.
+ * You are strictly forbidden to copy, download, store (in any medium), transmit, disseminate, adapt or change this material in any way unless prior written permission is obtained from GRAB. Access to the source code contained herein is hereby forbidden to anyone except current GRAB employees or contractors with binding Confidentiality and Non-disclosure agreements explicitly covering such access.
+ *
+ * The copyright notice above does not evidence any actual or intended publication or disclosure of this source code, which includes information that is confidential and/or proprietary, and is a trade secret, of GRAB.
+ * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC PERFORMANCE, OR PUBLIC DISPLAY OF OR THROUGH USE OF THIS SOURCE CODE WITHOUT THE EXPRESS WRITTEN CONSENT OF GRAB IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES. THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
+ */
+
+package com.grab.buildconfig
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
+import java.io.File
+
+class GeneratorCommand : CliktCommand() {
+
+    private val packageName: String by option(
+        "-p",
+        "--package",
+        help = "Package name of BuildConfig class"
+    ).required()
+
+    private val strings: List<String> by option(
+        "-s",
+        "--strings",
+        help = "List of name=value to be added as String type fields",
+    ).split(",").default(emptyList())
+
+    private val booleans: List<String> by option(
+        "-b",
+        "--booleans",
+        help = "List of name=value to be added as boolean type fields",
+    ).split(",").default(emptyList())
+
+    private val ints: List<String> by option(
+        "-i",
+        "--ints",
+        help = "List of name=value to be added as int type fields",
+    ).split(",").default(emptyList())
+
+    private val longs: List<String> by option(
+        "-l",
+        "--longs",
+        help = "List of name=value to be added as long type fields",
+    ).split(",").default(emptyList())
+
+    private val output by option(
+        "-o",
+        "--output",
+        help = "The output directory that the generated BuildConfig class will be written to",
+    ).convert { File(it) }
+
+    override fun run() {
+        BuildConfigGenerator().generate(
+            packageName = packageName,
+            output = output,
+            strings = strings,
+            booleans = booleans,
+            ints = ints,
+            longs = longs,
+        )
+    }
+}

--- a/tools/build_config/src/main/java/com/grab/buildconfig/GeneratorCommand.kt
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/GeneratorCommand.kt
@@ -51,9 +51,8 @@ class GeneratorCommand : CliktCommand() {
     private val output by option(
         "-o",
         "--output",
-        help = "The output directory that the generated BuildConfig class will be written to. " +
-                "Will write to standard output if option not present",
-    ).convert { File(it) }
+        help = "The BuildConfig.java location that the generated class will be written to."
+    ).convert { File(it) }.required()
 
     override fun run() {
         BuildConfigGenerator().generate(

--- a/tools/build_config/src/main/java/com/grab/buildconfig/main.kt
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/main.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2012-2023 Grab Taxi Holdings PTE LTD (GRAB), All Rights Reserved. NOTICE: All information contained herein is, and remains the property of GRAB. The intellectual and technical concepts contained herein are confidential, proprietary and controlled by GRAB and may be covered by patents, patents in process, and are protected by trade secret or copyright law.
+ * You are strictly forbidden to copy, download, store (in any medium), transmit, disseminate, adapt or change this material in any way unless prior written permission is obtained from GRAB. Access to the source code contained herein is hereby forbidden to anyone except current GRAB employees or contractors with binding Confidentiality and Non-disclosure agreements explicitly covering such access.
+ *
+ * The copyright notice above does not evidence any actual or intended publication or disclosure of this source code, which includes information that is confidential and/or proprietary, and is a trade secret, of GRAB.
+ * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC PERFORMANCE, OR PUBLIC DISPLAY OF OR THROUGH USE OF THIS SOURCE CODE WITHOUT THE EXPRESS WRITTEN CONSENT OF GRAB IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES. THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT MAY DESCRIBE, IN WHOLE OR IN PART.
+ */
+
+package com.grab.buildconfig
+
+import io.bazel.Worker
+
+fun main(args: Array<String>) {
+    GeneratorCommand().main(args)
+}

--- a/tools/build_config/src/main/java/com/grab/buildconfig/main.kt
+++ b/tools/build_config/src/main/java/com/grab/buildconfig/main.kt
@@ -11,5 +11,7 @@ package com.grab.buildconfig
 import io.bazel.Worker
 
 fun main(args: Array<String>) {
-    GeneratorCommand().main(args)
+    Worker.create(args) { cliArgs ->
+        GeneratorCommand().main(cliArgs)
+    }.run()
 }

--- a/tools/build_config/src/test/java/com/grab/buildconfig/BuildConfigTest.kt
+++ b/tools/build_config/src/test/java/com/grab/buildconfig/BuildConfigTest.kt
@@ -54,7 +54,7 @@ class BuildConfigTest {
             "String with special characters"
         )
         assertEquals(
-            "\$ Hello",
+            "\\$ Hello",
             BuildConfig.FIELD_WITH_ESCAPED_DOLLAR,
             "String with existing escaped dollar"
         )

--- a/tools/build_config/src/test/java/com/grab/buildconfig/BuildConfigTest.kt
+++ b/tools/build_config/src/test/java/com/grab/buildconfig/BuildConfigTest.kt
@@ -81,4 +81,9 @@ class BuildConfigTest {
     fun `assert generated longs in build config`() {
         assertEquals(123, BuildConfig.LONG, "Generated long is 0")
     }
+
+    @Test
+    fun `assert default config selected`() {
+        assertEquals("default value", BuildConfig.SELECT, "default value is selected")
+    }
 }


### PR DESCRIPTION
Moving the generation of BuildConfig to analysis phase so that it is able to support [configurable build attributes](https://bazel.build/docs/configurable-attributes) (`select()`).

The BuildConfig is now generated via a java tool that is executed via genrule in order to make use of genrule's cmd to expand given `select()` in dict values

Sample of `build_config` with `select()`:
```bazel
build_config(
    name = "foo-build-config",
    package_name = "foo.bar",
    booleans = {
        "SOME_BOOLEAN": "false",
    },
    ints = {
        "SOME_INT": 0,
        "VERSION_CODE": 1,
    },
    longs = {
        "SOME_LONG": 0,
    },
    strings = {
        "SOME_STRING": "Something",
        "VERSION_NAME": "1.0",
        "TESTING": select({
            "//foo:bar": ["select me"],
            "//conditions:default": ["default selected"],
        }),
        "THIS": "THAT",
        "FOO": "BAR",
    },
)
```

This generates a `BuildConfig.java` that looked like the following

```java
package foo.bar;

import java.lang.String;

public final class BuildConfig {
  public static final String SOME_STRING = "Something";

  public static final String VERSION_NAME = "1.0";

  public static final String TESTING = "default selected";

  public static final String THIS = "THAT";

  public static final String FOO = "BAR";

  public static final String BUILD_TYPE = "debug";

  public static final boolean SOME_BOOLEAN = Boolean.parseBoolean("false");

  public static final boolean DEBUG = Boolean.parseBoolean("true");

  public static final int SOME_INT = 0;

  public static final int VERSION_CODE = 1;

  public static final long SOME_LONG = 0L;
}
```