### PR TITLE
Use temp directory and clean it up during worker execution

### DIFF
--- a/tools/aapt_lite/src/main/java/com/grab/aapt/AaptLiteCommand.kt
+++ b/tools/aapt_lite/src/main/java/com/grab/aapt/AaptLiteCommand.kt
@@ -17,7 +17,12 @@
 package com.grab.aapt
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.*
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
 import com.grab.aapt.databinding.util.WorkingDirectory
 import java.io.File
 

--- a/tools/aapt_lite/src/main/java/com/grab/aapt/AaptLiteCommand.kt
+++ b/tools/aapt_lite/src/main/java/com/grab/aapt/AaptLiteCommand.kt
@@ -17,12 +17,8 @@
 package com.grab.aapt
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.convert
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.required
-import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.options.*
+import com.grab.aapt.databinding.util.WorkingDirectory
 import java.io.File
 
 class AaptLiteCommand : CliktCommand() {
@@ -75,30 +71,31 @@ class AaptLiteCommand : CliktCommand() {
 
         val classInfoZip = classInfos.map { File(it) }
         val depRTxts = rTxts.map { File(it) }
-        val baseDir = File(packageName.replace(".", File.separator))
 
-        val command = DaggerAaptLiteComponent.factory().create(
-            baseDir = baseDir,
-            packageName = packageName,
-            resourceFiles = resourcesFiles,
-            layoutFiles = layoutFiles,
-            classInfos = classInfoZip,
-            rTxts = depRTxts,
-            nonTransitiveRClass = nonTransitiveRClass,
-        )
-        val layoutBindings = command.layoutBindingsParser().parse(packageName, layoutFiles)
-        command.resToRClassGenerator().generate(packageName, resourcesFiles, depRTxts)
+        WorkingDirectory().use {
+            val command = DaggerAaptLiteComponent.factory().create(
+                baseDir = it.dir.toFile(),
+                packageName = packageName,
+                resourceFiles = resourcesFiles,
+                layoutFiles = layoutFiles,
+                classInfos = classInfoZip,
+                rTxts = depRTxts,
+                nonTransitiveRClass = nonTransitiveRClass,
+            )
+            val layoutBindings = command.layoutBindingsParser().parse(packageName, layoutFiles)
+            command.resToRClassGenerator().generate(packageName, resourcesFiles, depRTxts)
 
-        val rClasses = command.brClassGenerator().generate(packageName, layoutBindings)
-        command.srcJarPackager.packageSrcJar(inputDir = rClasses, outputFile = rClassSrcJar)
+            val rClasses = command.brClassGenerator().generate(packageName, layoutBindings)
+            command.srcJarPackager.packageSrcJar(inputDir = rClasses, outputFile = rClassSrcJar)
 
-        val dataBindingClasses = command.bindingClassGenerator().generate(
-            packageName,
-            layoutBindings
-        )
-        command.srcJarPackager.packageSrcJar(
-            inputDir = dataBindingClasses,
-            outputFile = stubClassJar
-        )
+            val dataBindingClasses = command.bindingClassGenerator().generate(
+                packageName,
+                layoutBindings
+            )
+            command.srcJarPackager.packageSrcJar(
+                inputDir = dataBindingClasses,
+                outputFile = stubClassJar
+            )
+        }
     }
 }

--- a/tools/aapt_lite/src/main/java/com/grab/aapt/BUILD.bazel
+++ b/tools/aapt_lite/src/main/java/com/grab/aapt/BUILD.bazel
@@ -15,6 +15,7 @@ kt_jvm_library(
         "//tools/aapt_lite/src/main/java/com/grab/aapt/databinding/di:aapt_scope",
         "//tools/aapt_lite/src/main/java/com/grab/aapt/databinding/mapper",
         "//tools/aapt_lite/src/main/java/com/grab/aapt/databinding/rclass",
+        "//tools/aapt_lite/src/main/java/com/grab/aapt/databinding/util",
         "//tools/aapt_lite/src/main/java/com/grab/aapt/databinding/util/jars",
         "//tools/worker:worker_lib",
     ],

--- a/tools/aapt_lite/src/main/java/com/grab/aapt/databinding/util/WorkingDirectory.kt
+++ b/tools/aapt_lite/src/main/java/com/grab/aapt/databinding/util/WorkingDirectory.kt
@@ -1,0 +1,13 @@
+package com.grab.aapt.databinding.util
+
+import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
+
+class WorkingDirectory(
+    val dir: Path = Files.createTempDirectory("tmp")
+) : Closeable {
+    override fun close() {
+        Files.walk(dir).sorted(Comparator.reverseOrder()).forEach(Files::delete)
+    }
+}


### PR DESCRIPTION
Use a temp directory during worker execution and clean it up during exit. This is needed to ensure worker state for multiple targets and repetitive builds are consitent. This would not be needed if sanboxing or worker 
sandboxing is enabled. 
