### PR TITLE
Don't remove qualifiers after resource merging if passed output files already contain it and enable workers

### DIFF
--- a/rules/android/private/resource_merger.bzl
+++ b/rules/android/private/resource_merger.bzl
@@ -36,8 +36,8 @@ def _resource_merger_impl(ctx):
         arguments = [args],
         progress_message = "%s %s" % (mnemonic, ctx.label),
         execution_requirements = {
-            "supports-workers": "0",
-            "supports-multiplex-workers": "0",
+            "supports-workers": "1",
+            "supports-multiplex-workers": "1",
             "requires-worker-protocol": "json",
             "worker-key-mnemonic": "MergeSourceSets",
         },

--- a/tools/aapt_lite/src/main/java/com/google/devtools/build/android/OutputFixer.kt
+++ b/tools/aapt_lite/src/main/java/com/google/devtools/build/android/OutputFixer.kt
@@ -9,10 +9,12 @@ object OutputFixer {
 
         // Merged directories will have qualifiers added by bazel which will not match the path specified in declaredOutputs, manually
         // walk and remove the suffixes like v4, v13 etc from the resource bucket directories.
+        // If provided output already contains version qualifiers then they can be allowed
+        val resDirs = declaredOutputs.map { it.substringBeforeLast("/").substringAfterLast("/") }.groupBy { it }
         outputDir.walk()
             .filter { it != outputDirPath }
             .filter { it.parentFile?.parentFile?.toPath() == outputDirPath }
-            .filter { it.isDirectory && it.name.matches(Regex(".*-v\\d+$")) }
+            .filter { it.isDirectory && it.name.matches(Regex(".*-v\\d+$")) && it.name !in resDirs }
             .forEach { resBucket ->
                 val newName = resBucket.name.split("-").dropLast(1).joinToString(separator = "-")
                 resBucket.renameTo(File(resBucket.parent, newName))

--- a/tools/aapt_lite/src/test/java/com/google/devtools/build/android/OutputFixerTest.kt
+++ b/tools/aapt_lite/src/test/java/com/google/devtools/build/android/OutputFixerTest.kt
@@ -47,4 +47,21 @@ class OutputFixerTest : BaseBindingStubTest() {
                 .all { it == EMPTY_RES_CONTENT }
         }
     }
+
+    @Test
+    fun `assert qualifiers are retained if provided output file paths already contain them`() {
+        val tmp = Files.createTempDirectory("tmp").toFile()
+        buildTestRes(tmp) {
+            "res/values-v4/strings.xml" {
+                """<?xml version="1.0" encoding="UTF-8" standalone="no"?><resources/>"""
+            }
+        }
+        OutputFixer.process(
+            outputDir = tmp,
+            declaredOutputs = listOf("res/values-v4/strings.xml")
+        )
+        assertTrue("Qualifiers are retained in merged directory") {
+            tmp.walk().any { it.name == "values-v4" && it.isDirectory }
+        }
+    }
 }


### PR DESCRIPTION
- Handle cases where source resources already contain qualifiers like `values-v21`
- Enable workers support for `MergeSourceSet`