### PR TITLE
Rename databinding kotlin to use the same suffix as `kt_android_library`

### DIFF
--- a/tests/android/BUILD.bazel
+++ b/tests/android/BUILD.bazel
@@ -6,6 +6,7 @@ android_library(
         "src/main/java/**/*.kt",
     ]),
     custom_package = "com.grab.test",
+    enable_data_binding = True,
     manifest = "src/main/AndroidManifest.xml",
     resources = {
         "src/main/res": {

--- a/tests/android/src/main/res/layout/layout_test.xml
+++ b/tests/android/src/main/res/layout/layout_test.xml
@@ -1,24 +1,28 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="16dp">
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <TextView
-        android:id="@+id/text"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp">
 
-    <TextView
-        android:id="@+id/text2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        <TextView
+            android:id="@+id/text2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
 
-</LinearLayout>
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+    </LinearLayout>
+</layout>

--- a/tools/databinding/databinding.bzl
+++ b/tools/databinding/databinding.bzl
@@ -97,7 +97,7 @@ def kt_db_android_library(
     )
 
     # Create an intermediate target for compiling all Kotlin classes used in Databinding
-    kotlin_target = name + "-kotlin"
+    kotlin_target = name + "_kt"
     kotlin_targets = []
 
     # List for holding binding adapter sources

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -2,6 +2,7 @@ GRAB_BAZEL_COMMON_ARTIFACTS = [
     "org.jetbrains.kotlin:kotlin-parcelize-compiler:1.8.10",
     "org.jetbrains.kotlin:kotlin-parcelize-runtime:1.8.10",
     "androidx.compose.compiler:compiler:1.4.3",
+    "androidx.annotation:annotation:1.5.0",
     "androidx.databinding:databinding-adapters:7.2.2",
     "androidx.databinding:databinding-common:7.2.2",
     "androidx.databinding:databinding-runtime:7.2.2",


### PR DESCRIPTION
The `-kotlin` suffix has no purpose and causes confusion in multiple places like test associates and grazel. In this PR, it is unified to be the same name that would be otherwise generated by kt_android_library.

Enable databinding in tests also so running unit tests will test databinding code path.