### PR TITLE
Fix lint tool to handle return status codes from LintCli

### DIFF
--- a/tools/lint/src/main/java/com/grab/lint/LintCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintCommand.kt
@@ -1,6 +1,7 @@
 package com.grab.lint
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
@@ -34,14 +35,14 @@ class LintCommand : CliktCommand() {
 
     override fun run() {
         runLint(analyzeOnly = true)
-        runLint(analyzeOnly = false)
-        // TODO Post process the results and fail the action
+        val statusCode = runLint(analyzeOnly = false)
+        throw ProgramResult(statusCode)
     }
 
-    private fun runLint(analyzeOnly: Boolean = false) {
+    private fun runLint(analyzeOnly: Boolean = false): Int {
         val outputDir = File(".").toPath()
         val baselineFile = outputDir.resolve("baseline.xml")
-        LintCli().run(
+        return LintCli().run(
             mutableListOf(
                 "--project", this.projectXml.toString(),
                 "--xml", this.outputXml.toString(),


### PR DESCRIPTION
The current LintCommand uses clikt to take in cli arguments and run Android's lint CLI. 

The Android's lint CLI is actually return a status code which wasn't handled in our LintCommand which causes our lint to ignore the exit status and passes the build.

See [Custom Exit Status](https://ajalt.github.io/clikt/advanced/#custom-exit-status-codes)