### PR TITLE
Integrate with `rules_android_lint`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,8 +8,7 @@ build --experimental_android_databinding_v2
 build --android_databinding_use_v3_4_args
 build --android_databinding_use_androidx
 
-build --experimental_google_legacy_api
-query --experimental_google_legacy_api
+common --experimental_google_legacy_api
 
 common --strategy=AndroidLint=sandboxed
 

--- a/rules/android/android_binary.bzl
+++ b/rules/android/android_binary.bzl
@@ -3,6 +3,7 @@ load("@grab_bazel_common//tools/res_value:res_value.bzl", "res_value")
 load("@grab_bazel_common//tools/kotlin:android.bzl", "kt_android_library")
 load("@grab_bazel_common//rules/android/databinding:databinding.bzl", "DATABINDING_DEPS")
 load("@grab_bazel_common//rules/android/lint:defs.bzl", "lint_sources", "lint_test")
+load("@rules_android_lint//rules:defs.bzl", "android_lint_test")
 load(":resources.bzl", "build_resources")
 
 """Enhanced android_binary rule with support for build configs, res values, Kotlin compilation and databinding support"""
@@ -102,4 +103,12 @@ def android_binary(
     lint_test(
         name = name + ".lint",
         target = name,
+    )
+
+    android_lint_test(
+        name = name + "_lint_test",
+        srcs = attrs.get("srcs", default = []),
+        resource_files = [file for file in resource_files if file.endswith(".xml")],
+        lib = name,
+        deps = android_binary_deps,
     )

--- a/rules/android/android_binary.bzl
+++ b/rules/android/android_binary.bzl
@@ -6,8 +6,6 @@ load("@grab_bazel_common//rules/android/lint:defs.bzl", "lint_sources", "lint_te
 load("@rules_android_lint//rules:defs.bzl", "android_lint_test")
 load(":resources.bzl", "build_resources")
 
-"""Enhanced android_binary rule with support for build configs, res values, Kotlin compilation and databinding support"""
-
 def android_binary(
         name,
         debug = True,
@@ -16,19 +14,23 @@ def android_binary(
         res_values = {},
         enable_data_binding = False,
         enable_compose = True,
+        lint_options = {},
         **attrs):
     """
-    `android_binary` wrapper that adds Kotlin, build config, databinding and res values support. The attrs are passed to native `android_binary`
-    unless otherwise stated.
+    `android_binary` wrapper that setups a native.android_binary with various customizations
 
     Args:
-    - name: Name of the target
-    - build_config: `dict` accepting various types such as `strings`, `booleans`, `ints`, `longs` and their corresponding values for generating
+      name: Name of the target
+      debug: Whether to enable debug,
+      build_config: `dict` accepting various types such as `strings`, `booleans`, `ints`, `longs` and their corresponding values for generating
                     build config fields
-    - res_value: `dict` accepting `string` key and their values. The value will be used to generate android resources and then adds as a
+      res_values: `dict` accepting `string` key and their values. The value will be used to generate android resources and then adds as a
                  resource for `android_binary`.
-    - enable_data_binding: Enable android databinding support for this target
-    - enable_compose: Enable Jetpack Compose support for this target
+      custom_package: The package name for android_binary, must be same as one declared in AndroidManifest.xml
+      lint_options: Lint options to pass to lint, typically contains baselines and config.xml
+      enable_data_binding: Enable android databinding support for this target
+      enable_compose: Enable Jetpack Compose support for this target
+      **attrs: Additional attrs to pass to generated android_binary.
     """
 
     build_config_target = name + "_build_cfg"

--- a/rules/android/android_binary.bzl
+++ b/rules/android/android_binary.bzl
@@ -111,6 +111,8 @@ def android_binary(
         name = name + "_lint_test",
         srcs = attrs.get("srcs", default = []),
         resource_files = [file for file in resource_files if file.endswith(".xml")],
+        manifest = attrs.get("manifest"),
         lib = name,
+        baseline = "lint_baseline.xml",
         deps = android_binary_deps,
     )

--- a/rules/android/android_library.bzl
+++ b/rules/android/android_library.bzl
@@ -6,8 +6,6 @@ load("@grab_bazel_common//rules/android/lint:defs.bzl", "lint_sources", "lint_te
 load("@rules_android_lint//rules:defs.bzl", "android_lint_test")
 load(":resources.bzl", "build_resources")
 
-"""Enhanced android_library rule with support for build configs, res values, Kotlin compilation and databinding support"""
-
 def android_library(
         name,
         debug = True,
@@ -17,18 +15,24 @@ def android_library(
         res_values = {},
         enable_data_binding = False,
         enable_compose = False,
+        lint_options = {},
         **attrs):
     """
-    `android_library` wrapper that adds Kotlin, build config, databinding and res values support.
+    `android_binary` wrapper that setups a native.android_binary with various customizations
 
     Args:
-    - name: Name of the target
-    - build_config: `dict` accepting various types such as `strings`, `booleans`, `ints`, `longs` and their corresponding values for generating
+      name: Name of the target
+      debug: Whether to enable debug,
+      srcs: Source files for the library, can contain mix of java and kotlin files.
+      build_config: `dict` accepting various types such as `strings`, `booleans`, `ints`, `longs` and their corresponding values for generating
                     build config fields
-    - res_value: `dict` accepting `string` key and their values. The value will be used to generate android resources and then adds as a
-                 resource for `android_library`.
-    - enable_data_binding: Enable android databinding support for this target
-    - enable_compose: Enable Jetpack Compose support for this target
+      res_values: `dict` accepting `string` key and their values. The value will be used to generate android resources and then adds as a
+                 resource for `android_binary`.
+      custom_package: The package name for android_binary, must be same as one declared in AndroidManifest.xml
+      lint_options: Lint options to pass to lint, typically contains baselines and config.xml
+      enable_data_binding: Enable android databinding support for this target
+      enable_compose: Enable Jetpack Compose support for this target
+      **attrs: Additional attrs to pass to generated android_binary.
     """
 
     build_config_target = name + "_build_cfg"
@@ -73,7 +77,7 @@ def android_library(
     if enable_data_binding:
         rule_type = kt_db_android_library
     elif len(srcs) == 0 and len(resource_files) != 0:
-        rules_type = native.android_library
+        rule_type = native.android_library
     elif len(srcs) != 0:
         rule_type = kt_android_library
 

--- a/rules/android/android_library.bzl
+++ b/rules/android/android_library.bzl
@@ -2,8 +2,9 @@ load("@grab_bazel_common//tools/build_config:build_config.bzl", _build_config = 
 load("@grab_bazel_common//tools/res_value:res_value.bzl", "res_value")
 load("@grab_bazel_common//tools/kotlin:android.bzl", "kt_android_library")
 load("@grab_bazel_common//rules/android/databinding:databinding.bzl", "kt_db_android_library")
-load(":resources.bzl", "build_resources")
 load("@grab_bazel_common//rules/android/lint:defs.bzl", "lint_sources", "lint_test")
+load("@rules_android_lint//rules:defs.bzl", "android_lint_test")
+load(":resources.bzl", "build_resources")
 
 """Enhanced android_library rule with support for build configs, res values, Kotlin compilation and databinding support"""
 
@@ -93,4 +94,12 @@ def android_library(
     lint_test(
         name = name + ".lint",
         target = name,
+    )
+
+    android_lint_test(
+        name = name + "_lint_test",
+        srcs = attrs.get("srcs", default = []),
+        resource_files = [file for file in resource_files if file.endswith(".xml")],
+        lib = name,
+        deps = android_library_deps,
     )

--- a/rules/android/android_library.bzl
+++ b/rules/android/android_library.bzl
@@ -104,6 +104,7 @@ def android_library(
         name = name + "_lint_test",
         srcs = attrs.get("srcs", default = []),
         resource_files = [file for file in resource_files if file.endswith(".xml")],
+        manifest = attrs.get("manifest"),
         lib = name,
         deps = android_library_deps,
     )

--- a/rules/android/lint/lint.bzl
+++ b/rules/android/lint/lint.bzl
@@ -221,7 +221,7 @@ def _lint_aspect_impl(target, ctx):
                 lint_config_xml_file = sources.lint_config_xml,
                 lint_result_xml_file = lint_result_xml_file,
                 partial_results_dir = partial_results_dir,
-                verbose = True,
+                verbose = False,
                 inputs = depset(
                     sources.srcs +
                     sources.resources +

--- a/rules/android/resources.bzl
+++ b/rules/android/resources.bzl
@@ -94,3 +94,6 @@ def build_resources(
         return merged_resources + generated_resources
     else:
         return resource_files + generated_resources
+
+def resources_xml(resource_files):
+    return [file for file in resource_files if file.endswith(".xml")]

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def http_archive(name, **kwargs):
     maybe(_http_archive, name = name, **kwargs)
@@ -66,7 +67,23 @@ def _proto():
         ],
     )
 
+def _lint():
+    git_repository(
+        name = "rules_android_lint",
+        commit = "012f2b1b0a8ffcad878111d6e2e8b903bc29f985",
+        remote = "https://github.com/Bencodes/rules_android_lint.git",
+        workspace_file = "@grab_bazel_common//third_party/rules_android_lint:WORKSPACE.bazelignore",
+        patch_cmds = [
+            "rm WORKSPACE.bazel",
+            "echo \"common --experimental_google_legacy_api\" > .bazelrc",
+        ],
+        repo_mapping = {
+            "@rules_kotlin": "@io_bazel_rules_kotlin",
+        },
+    )
+
 def bazel_common_dependencies():
     #_proto
     _maven()
     _kotlin()
+    _lint()

--- a/rules/setup.bzl
+++ b/rules/setup.bzl
@@ -52,6 +52,8 @@ def bazel_common_setup(
         ),
     )
 
+    native.register_toolchains("@rules_android_lint//toolchains:android_lint_default_toolchain")
+
     repo_name = "bazel_common_maven"
     maven_install_json = "@grab_bazel_common//:%s_install.json" % repo_name if pinned_maven_install else None
 
@@ -91,6 +93,31 @@ def bazel_common_setup(
         strict_visibility = True,
         maven_install_json = maven_install_json,
         fetch_sources = True,
+    )
+
+    maven_install(
+        name = "rules_android_lint_deps",
+        artifacts = [
+            # Testing
+            "org.assertj:assertj-core:3.24.2",
+            "junit:junit:4.13.2",
+            # Worker Dependencies
+            "com.squareup.moshi:moshi:1.15.0",
+            "com.squareup.moshi:moshi-kotlin:1.15.0",
+            "com.squareup.okio:okio-jvm:3.6.0",
+            "io.reactivex.rxjava3:rxjava:3.1.8",
+            "com.xenomachina:kotlin-argparser:2.0.7",
+            # Lint Dependencies
+            "com.android.tools.lint:lint:31.3.0-alpha09",
+            "com.android.tools.lint:lint-api:31.3.0-alpha09",
+            "com.android.tools.lint:lint-checks:31.3.0-alpha09",
+            "com.android.tools.lint:lint-model:31.3.0-alpha09",
+        ],
+        #maven_install_json = "@rules_android_lint//:maven_install.json",
+        repositories = [
+            "https://maven.google.com",
+            "https://repo1.maven.org/maven2",
+        ],
     )
 
     _android(patched_android_tools)

--- a/third_party/rules_android_lint/WORKSPACE.bazelignore
+++ b/third_party/rules_android_lint/WORKSPACE.bazelignore
@@ -1,0 +1,164 @@
+workspace(name = "rules_android_lint")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "cgrindel_bazel_starlib",
+    sha256 = "9090280a9cff7322e7c22062506b3273a2e880ca464e520b5c77fdfbed4e8805",
+    urls = [
+        "https://github.com/cgrindel/bazel-starlib/releases/download/v0.18.1/bazel-starlib.v0.18.1.tar.gz",
+    ],
+)
+
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+http_archive(
+    name = "rules_java",
+    sha256 = "e81e9deaae0d9d99ef3dd5f6c1b32338447fe16d5564155531ea4eb7ef38854b",
+    urls = [
+        "https://github.com/bazelbuild/rules_java/releases/download/7.0.6/rules_java-7.0.6.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
+    strip_prefix = "rules_proto-4.0.0-3.20.0",
+    urls = [
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
+    ],
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_JVM_EXTERNAL_TAG = "5.3"
+RULES_JVM_EXTERNAL_SHA ="d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac"
+
+http_archive(
+    name = "rules_jvm_external",
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/%s/rules_jvm_external-%s.tar.gz" % (RULES_JVM_EXTERNAL_TAG, RULES_JVM_EXTERNAL_TAG)
+)
+
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+rules_kotlin_version = "1.9.0"
+rules_kotlin_sha = "5766f1e599acf551aa56f49dab9ab9108269b03c557496c54acaf41f98e2b8d6"
+http_archive(
+    name = "rules_kotlin",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin-v%s.tar.gz" % (rules_kotlin_version, rules_kotlin_version)],
+    sha256 = rules_kotlin_sha,
+)
+
+load("@rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+kotlin_repositories()
+
+load("@rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+kt_register_toolchains()
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+    ],
+    sha256 = "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74",
+)
+
+register_toolchains("//toolchains:android_lint_default_toolchain")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
+    strip_prefix = "bazel-lib-1.32.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+
+aspect_bazel_lib_dependencies()
+
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "72b5bb0853aac597cce6482ee6c62513318e7f2c0050bc7c319d75d03d8a3875",
+    strip_prefix = "buildifier-prebuilt-6.3.3",
+    urls = [
+        "http://github.com/keith/buildifier-prebuilt/archive/6.3.3.tar.gz",
+    ],
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:specs.bzl", "maven")
+
+maven_install(
+    name = "rules_android_lint_deps",
+    artifacts = [
+        # Testing
+        "org.assertj:assertj-core:3.24.2",
+        "junit:junit:4.13.2",
+        # Worker Dependencies
+        # TODO(bencodes) Remove these and use the worker impl. that Bazel defines internally
+        "com.squareup.moshi:moshi:1.15.0",
+        "com.squareup.moshi:moshi-kotlin:1.15.0",
+        "com.squareup.okio:okio-jvm:3.6.0",
+        "io.reactivex.rxjava3:rxjava:3.1.8",
+        "com.xenomachina:kotlin-argparser:2.0.7",
+        # Lint Dependencies
+        "com.android.tools.lint:lint:31.3.0-alpha09",
+        "com.android.tools.lint:lint-api:31.3.0-alpha09",
+        "com.android.tools.lint:lint-checks:31.3.0-alpha09",
+        "com.android.tools.lint:lint-model:31.3.0-alpha09",
+    ],
+    #maven_install_json = "@rules_android_lint//:maven_install.json",
+    repositories = [
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+
+#load("@rules_android_lint_deps//:defs.bzl", rules_android_lint_deps_pinned_maven_install = "pinned_maven_install")
+
+#rules_android_lint_deps_pinned_maven_install()


### PR DESCRIPTION
Attempt integration with [rules_android_lint](https://github.com/Bencodes/rules_android_lint)

https://github.com/Bencodes/rules_android_lint does not support `WORKSPACE` application so this change uses `git_repository` and custom patch cmds to make it compatible.

`_lint_test` targets are added to each `android_library` and `android_binary` targets. Lint can be run with `bazelisk test target_lint_test`

BzlMod: https://github.com/grab/grab-bazel-common/issues/81 