### PR TITLE
Fix stale results in `partial-results-dir` getting reused when running lint in worker mode

### DIFF
--- a/tools/lint/src/main/java/com/grab/lint/LintAnalyzeCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintAnalyzeCommand.kt
@@ -13,6 +13,12 @@ class LintAnalyzeCommand : LintBaseCommand() {
 
     override val createProjectXml: Boolean = true
 
+    override fun preRun() {
+        // For analyze, always clear previous lint results
+        partialResults.deleteRecursively()
+        Files.createDirectories(partialResults.toPath())
+    }
+
     override fun run(
         workingDir: Path,
         projectXml: File,

--- a/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt
@@ -104,11 +104,10 @@ abstract class LintBaseCommand : CliktCommand() {
     )
 
     override fun run() {
+        preRun()
         prepareJdk()
         WorkingDirectory().use {
             val workingDir = it.dir
-            // val partialResults = resolveSymlinks(partialResults, workingDir)
-
             val projectXml = if (!createProjectXml) projectXml else {
                 ProjectXmlCreator(projectXml).create(
                     name = name,
@@ -132,6 +131,11 @@ abstract class LintBaseCommand : CliktCommand() {
         }
     }
 
+    /**
+     * Executes for before running any common logic
+     */
+    abstract fun preRun()
+
     abstract fun run(
         workingDir: Path,
         projectXml: File,
@@ -142,10 +146,13 @@ abstract class LintBaseCommand : CliktCommand() {
      * Create new project.xml at [projectXml].
      *
      * Required for non-sandbox modes since we can't rely on file system state when executing in non sandbox modes as previous results might
-     * be still there.
+     * be still there. When true, a new project XML will be created at [projectXml] and if `false` will use the project xml at this location
      */
     abstract val createProjectXml: Boolean
 
+    /**
+     * Common options for Lint across different types of invocations, analyze or report.
+     */
     protected val defaultLintOptions
         get() = mutableListOf(
             "--config", lintConfig.toString(),

--- a/tools/lint/src/main/java/com/grab/lint/LintReportCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintReportCommand.kt
@@ -43,6 +43,10 @@ class LintReportCommand : LintBaseCommand() {
 
     override val createProjectXml = false
 
+    override fun preRun() {
+        // No-op
+    }
+
     private fun runLint(workingDir: Path, projectXml: File, tmpBaseline: File): File {
         val cliArgs = (defaultLintOptions + listOf(
             "--project", projectXml.toString(),


### PR DESCRIPTION
- `partial-results-dir` is outside of `WorkingDirectory` hence not guranteed to be cleaned after worker execution hence manually clean it.
- Don't clean it during LintReport because it is an input directory during report.