### PR TITLE
Fix lint aspect not linting non databinding targets

### DIFF
--- a/rules/android/android_library.bzl
+++ b/rules/android/android_library.bzl
@@ -3,7 +3,7 @@ load("@grab_bazel_common//tools/res_value:res_value.bzl", "res_value")
 load("@grab_bazel_common//tools/kotlin:android.bzl", "kt_android_library")
 load("@grab_bazel_common//rules/android/databinding:databinding.bzl", "kt_db_android_library")
 load(":resources.bzl", "build_resources")
-load("@grab_bazel_common//rules/android/lint:defs.bzl", "lint", "lint_sources")
+load("@grab_bazel_common//rules/android/lint:defs.bzl", "LINT_ENABLED", "lint", "lint_sources")
 
 def android_library(
         name,
@@ -92,7 +92,7 @@ def android_library(
         assets = attrs.get("assets", default = None),
         assets_dir = attrs.get("assets_dir", default = None),
         visibility = attrs.get("visibility", default = None),
-        tags = attrs.get("tags", default = []) + ["lint_enabled"],
+        tags = attrs.get("tags", default = []) + [LINT_ENABLED],
         deps = android_library_deps,
         plugins = attrs.get("plugins", default = None),
     )

--- a/rules/android/lint/lint_aspect.bzl
+++ b/rules/android/lint/lint_aspect.bzl
@@ -312,10 +312,11 @@ def _lint_aspect_impl(target, ctx):
     else:
         # Current target info
         rule_kind = ctx.rule.kind
+        kotlin = rule_kind == "kt_jvm_library"
         android = rule_kind == "android_library" or rule_kind == "android_binary"
         library = rule_kind != "android_binary"
 
-        enabled = LINT_ENABLED in ctx.rule.attr.tags and android  # Currently only android targets
+        enabled = LINT_ENABLED in ctx.rule.attr.tags and (android or kotlin)
 
         # Dependency info
         transitive_lint_node_infos = _transitive_lint_node_infos(ctx)

--- a/tools/databinding/databinding.bzl
+++ b/tools/databinding/databinding.bzl
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load(":databinding_stubs.bzl", "databinding_stubs")
+load("@grab_bazel_common//rules/android/lint:defs.bzl", "LINT_ENABLED")
 # load(":databinding_aar.bzl", "databinding_aar")
 
 # TODO(arun) Replace with configurable maven targets
@@ -119,7 +120,7 @@ def kt_db_android_library(
                 "@grab_bazel_common//tools/binding-adapter-bridge:binding-adapter-bridge",
                 "@grab_bazel_common//tools/android:android_sdk",
             ],
-            tags = tags,
+            tags = [tag for tag in tags if tag != LINT_ENABLED],
         )
         kotlin_targets.append(kotlin_target)
 


### PR DESCRIPTION
* Update aspect to visit `kt_jvm_library` as well
* Fix passing tags to inner `_kt` in databinding targets (sometimes was causing a target to be linted twice)
