### PR TITLE
Ensure android-kotlin sandwich targets are treated as android modules during lint analysis

### DIFF
--- a/rules/android/lint/lint_aspect.bzl
+++ b/rules/android/lint/lint_aspect.bzl
@@ -313,7 +313,9 @@ def _lint_aspect_impl(target, ctx):
         # Current target info
         rule_kind = ctx.rule.kind
         kotlin = rule_kind == "kt_jvm_library"
-        android = rule_kind == "android_library" or rule_kind == "android_binary"
+
+        #TODO(arun) Remove name based detection and inject value into lint_sources from macro and read it later
+        android = rule_kind == "android_library" or rule_kind == "android_binary" or (kotlin and target.label.name.endswith("_kt"))
         library = rule_kind != "android_binary"
 
         enabled = LINT_ENABLED in ctx.rule.attr.tags and (android or kotlin)


### PR DESCRIPTION
For a case like this 

```mermaid
flowchart LR
    A("A(android_binary)") --> B("B(android_library) (kotlin)")
```

B was wrongly treated as a non android target during lint analysis in A. 

Short-term fix using name to detect the sandwich target, long-term need to rework `lint_sources` to hold this information.