### PR TITLE
Add compose support to android_instrumentation_binary

### DIFF
--- a/rules/android/android_instrumentation.bzl
+++ b/rules/android/android_instrumentation.bzl
@@ -15,6 +15,7 @@ def android_instrumentation_binary(
         resource_files = [],
         associates = [],
         test_instrumentation_runner = "androidx.test.runner.AndroidJUnitRunner",
+        enable_compose = False,
         **kwargs):
     """A macro that creates an Android instrumentation binary.
 
@@ -40,6 +41,8 @@ def android_instrumentation_binary(
     )
 
     android_library_name = name + "_lib"
+    if enable_compose:
+        deps.extend(["@grab_bazel_common//rules/android/compose:compose-plugin"])
 
     # TODO: Migrate to android_library
     kt_android_library(


### PR DESCRIPTION
#102 Added compose support for `android_library` and `android_binary` but have seem to missed out adding support for `android_instrumentation_binary`. 

This PR will allow the compose compiler to be added to Kotlin compilation in `android_instrumentation_binary` when `enable_compose` is set to `True`.