### PR TITLE
Configure lint model variant values with input from bazel instead of hardcoding

### DIFF
--- a/rules/android/android_binary.bzl
+++ b/rules/android/android_binary.bzl
@@ -111,6 +111,7 @@ def android_binary(
         manifest = attrs.get("manifest"),
         multidex = attrs.get("multidex", default = None),
         manifest_values = attrs.get("manifest_values", default = None),
+        resource_configuration_filters = attrs.get("resource_configuration_filters", default = None),
         plugins = attrs.get("plugins", default = None),
         tags = tags,
         visibility = attrs.get("visibility", default = None),

--- a/tests/android/binary/BUILD.bazel
+++ b/tests/android/binary/BUILD.bazel
@@ -19,6 +19,19 @@ android_binary(
         "targetSdkVersion": "31",
         "applicationId": "com.grab.test",
     },
+    resource_configuration_filters = [
+        "en",
+        "id",
+        "in",
+        "km",
+        "ms",
+        "my",
+        "th",
+        "vi",
+        "zh",
+        "ko",
+        "ja",
+    ],
     resources = {
         "src/main/res": {
         },

--- a/tools/lint/src/main/java/com/grab/lint/LintAnalyzeCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintAnalyzeCommand.kt
@@ -30,10 +30,10 @@ class LintAnalyzeCommand : LintBaseCommand() {
             "--analyze-only" // Only do analyze
         )).toTypedArray()
         LintCli().run(cliArgs)
-        postProcessPartialResults(workingDir)
+        postProcessPartialResults()
     }
 
-    private fun postProcessPartialResults(workingDir: Path) {
+    private fun postProcessPartialResults() {
         Files.walk(partialResults.toPath())
             .filter { it.isRegularFile() }
             .collect(Collectors.toList())

--- a/tools/lint/src/main/java/com/grab/lint/LintModelCreator.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintModelCreator.kt
@@ -66,6 +66,7 @@ class LintModelCreator(
         variant.writeText(
             buildVariant(
                 android = android,
+                library = library,
                 minSdkVersion = minSdkVersion,
                 targetSdkVersion = targetSdkVersion,
                 packageName = packageName,
@@ -112,6 +113,7 @@ class LintModelCreator(
     @Suppress("UnnecessaryVariable", "UNUSED_PARAMETER")
     private fun buildVariant(
         android: Boolean,
+        library: Boolean,
         minSdkVersion: String,
         targetSdkVersion: String,
         packageName: String?,
@@ -121,7 +123,7 @@ class LintModelCreator(
         buildDir: Path,
         sourceProvider: String
     ): String {
-        val sdkVersions = if (android) """
+        val sdkVersions = if (android && !library) """
             |minSdkVersion="$minSdkVersion"
             |    targetSdkVersion="$targetSdkVersion"
         """.trimMargin() else ""
@@ -135,7 +137,7 @@ class LintModelCreator(
         |    name="main"
         |    $sdkVersions
         |    debuggable="true"
-        |    useSupportLibraryVectorDrawables="true"
+        |    useSupportLibraryVectorDrawables="true" 
         |    ${packageName?.let { """package="$it"""" } ?: ""}
         |    partialResultsDir="$partialResultsDir"
         |    $resourceConfigurations

--- a/tools/lint/src/main/java/com/grab/lint/LintModelCreator.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintModelCreator.kt
@@ -18,6 +18,7 @@ class LintModelCreator(
      */
     fun create(
         projectName: String,
+        android: Boolean,
         library: Boolean,
         compileSdkVersion: String?,
         minSdkVersion: String,
@@ -28,20 +29,21 @@ class LintModelCreator(
         resources: List<String>,
         manifest: File?,
         mergedManifest: File?,
-        packageName: String? = "com.android.lint", // TODO pass from bazel
-        javaSourceLevel: String = "1.8", // TODO pass from bazel
-        resConfigs: List<String> = listOf("en", "id", "in", "km", "ms", "my", "th", "vi", "zh", "ko", "ja")  // TODO pass from bazel
+        resConfigs: List<String>,
+        packageName: String?,
+        javaSourceLevel: String = "1.8" // TODO pass from bazel
     ): File {
-        val lintModelXml = modelsDir.toPath().createDirectories().resolve("module.xml")
-        val buildDir = modelsDir.toPath().resolve("build").createDirectories() // Hack - if needed create a dedicate build folder
+        val modelPath = modelsDir.toPath().createDirectories()
+        val lintModelXml = modelPath.resolve("module.xml")
+        val buildDir = modelPath.resolve("build").createDirectories() // Hack - if needed create a dedicate build folder
         val lintModuleType = when {
             library -> LIBRARY
             else -> APP
         }
 
         // Manually relativize path from models dir to exec root
-        val pwd = env.pwd
-        val relativeProjectPath = modelsDir.toPath().absolute().relativize(Paths.get(pwd).absolute())
+        val pwd = Paths.get(env.pwd)
+        val relativeProjectPath = modelPath.absolute().relativize(pwd.absolute())
 
         lintModelXml.writeText(
             """
@@ -63,6 +65,7 @@ class LintModelCreator(
         val variant = modelsDir.resolve("main.xml")
         variant.writeText(
             buildVariant(
+                android = android,
                 minSdkVersion = minSdkVersion,
                 targetSdkVersion = targetSdkVersion,
                 packageName = packageName,
@@ -71,7 +74,7 @@ class LintModelCreator(
                 mergedManifest = mergedManifest,
                 buildDir = buildDir,
                 sourceProvider = buildSourceProvider(srcs, resources, manifest)
-            ).trimMargin()
+            )
         )
 
         val artifact = modelsDir.resolve("main-artifact-libraries.xml")
@@ -99,14 +102,16 @@ class LintModelCreator(
         // TODO assets
         return """
             |<sourceProvider
-            |    ${manifest?.let { """  manifest="$manifest"""" } ?: ""}
-            |    ${dirString(srcs)?.let { """  javaDirectories="$it"""" } ?: ""}
-            |    ${dirString(resources, isResources = true)?.let { """  resDirectories="$it"""" } ?: ""}/>
+            |    ${manifest?.let { """manifest="$it"""" } ?: ""}
+            |    ${dirString(srcs)?.let { """javaDirectories="$it"""" } ?: ""}
+            |    ${dirString(resources, isResources = true)?.let { """resDirectories="$it"""" } ?: ""}/>
         """.trimMargin()
     }
 
 
+    @Suppress("UnnecessaryVariable", "UNUSED_PARAMETER")
     private fun buildVariant(
+        android: Boolean,
         minSdkVersion: String,
         targetSdkVersion: String,
         packageName: String?,
@@ -115,28 +120,38 @@ class LintModelCreator(
         mergedManifest: File?,
         buildDir: Path,
         sourceProvider: String
-    ): String = """
-                    |<variant
-                    |       name="main"
-                    |       minSdkVersion="$minSdkVersion"
-                    |       targetSdkVersion="$targetSdkVersion"
-                    |       debuggable="true"
-                    |       useSupportLibraryVectorDrawables="true"
-                    |       package="$packageName"
-                    |       partialResultsDir="$partialResultsDir"
-                    |       resourceConfigurations="${resConfigs.joinToString(separator = ",")}"
-                    |       mergedManifest="$mergedManifest">
-                    |     <buildFeatures />
-                    |     <sourceProviders>
-                    |       
-                    |     </sourceProviders>
-                    |     <artifact
-                    |       type="MAIN"
-                    |       classOutputs="${buildDir.resolve("classes").createDirectories()}"
-                    |       applicationId="$packageName">
-                    |     </artifact>
-                    |   </variant>
-                """.trimMargin()
+    ): String {
+        val sdkVersions = if (android) """
+            |minSdkVersion="$minSdkVersion"
+            |    targetSdkVersion="$targetSdkVersion"
+        """.trimMargin() else ""
+
+        val resourceConfigurations = if (resConfigs.isNotEmpty()) """
+            |resourceConfigurations="${resConfigs.joinToString(separator = ",")}"
+        """.trimMargin() else ""
+
+        val variant = """
+        |<variant
+        |    name="main"
+        |    $sdkVersions
+        |    debuggable="true"
+        |    useSupportLibraryVectorDrawables="true"
+        |    ${packageName?.let { """package="$it"""" } ?: ""}
+        |    partialResultsDir="$partialResultsDir"
+        |    $resourceConfigurations
+        |    mergedManifest="$mergedManifest">
+        |    <buildFeatures />
+        |    <sourceProviders>
+        |    </sourceProviders>
+        |    <artifact
+        |      type="MAIN"
+        |      classOutputs="${buildDir.resolve("classes").createDirectories()}"
+        |      applicationId="$packageName">
+        |    </artifact>
+        |</variant>
+        |""".trimMargin()
+        return variant
+    }
 
     /**
      * Provided a list of file paths return the common parent directory.

--- a/tools/lint/src/main/java/com/grab/lint/ProjectXmlCreator.kt
+++ b/tools/lint/src/main/java/com/grab/lint/ProjectXmlCreator.kt
@@ -5,14 +5,14 @@ import java.io.File
 import java.nio.file.Paths
 import kotlin.io.path.exists
 
-private fun List<String>.lintJars(): Sequence<String> =
-    this.asSequence().map {
-        Paths.get(it.split("^")[1]).resolve("lint.jar")
-    }.filter { it.exists() }.map { it.toString() }
-
 class ProjectXmlCreator(
     private val projectXml: File,
 ) {
+
+    private fun List<String>.lintJars(): Sequence<String> = asSequence()
+        .map { Paths.get(it.split("^")[1]).resolve("lint.jar") }
+        .filter { it.exists() }
+        .map { it.toString() }
 
     private fun moduleXml(
         name: String,
@@ -35,12 +35,16 @@ class ProjectXmlCreator(
         android: Boolean,
         library: Boolean,
         compileSdkVersion: String,
+        minSdkVersion: String,
+        targetSdkVersion: String,
         partialResults: File,
         modelsDir: File,
         srcs: List<String>,
         resources: List<String>,
         aarDeps: List<String>,
         classpath: List<String>,
+        resConfigs: List<String>,
+        packageName: String?,
         manifest: File?,
         mergedManifest: File?,
         dependencies: List<LintDependency>,
@@ -51,16 +55,19 @@ class ProjectXmlCreator(
             modelsDir
         } else LintModelCreator().create(
             compileSdkVersion = compileSdkVersion,
+            android = android,
             library = library,
             projectName = name,
-            minSdkVersion = "21", // TODO(arun) Pass from project
-            targetSdkVersion = "34", // TODO(arun) Pass from project
+            minSdkVersion = minSdkVersion,
+            targetSdkVersion = targetSdkVersion,
             mergedManifest = mergedManifest,
             partialResultsDir = partialResults,
             modelsDir = modelsDir,
             srcs = srcs,
             resources = resources,
+            packageName = packageName,
             manifest = manifest,
+            resConfigs = resConfigs,
         )
 
         val contents = buildString {
@@ -70,9 +77,6 @@ class ProjectXmlCreator(
             srcs.forEach { src ->
                 appendLine("  <src file=\"$src\" test=\"false\" />")
             }
-            //resources.forEach { resource ->
-            //      appendLine("  <resource file=\"$resource\" />")
-            //}
             // Certain detectors need res folder as input, eg: MissingTranslation
             resFolders(resources).forEach { resource ->
                 appendLine("  <resource file=\"$resource\" />")

--- a/tools/lint/src/test/java/com/grab/lint/LintModelCreatorTest.kt
+++ b/tools/lint/src/test/java/com/grab/lint/LintModelCreatorTest.kt
@@ -71,7 +71,7 @@ class LintModelCreatorTest : BaseTest() {
         lintModelCreator.create(
             compileSdkVersion = "30",
             android = false,
-            library = false,
+            library = true,
             projectName = "//test",
             minSdkVersion = "21",
             targetSdkVersion = "34",

--- a/tools/lint/src/test/java/com/grab/lint/LintModelCreatorTest.kt
+++ b/tools/lint/src/test/java/com/grab/lint/LintModelCreatorTest.kt
@@ -6,6 +6,7 @@ import com.grab.cli.WorkingDirectory
 import com.grab.test.BaseTest
 import org.junit.Before
 import org.junit.Test
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
@@ -17,20 +18,24 @@ class LintModelCreatorTest : BaseTest() {
 
     private lateinit var lintModelCreator: LintModelCreator
     private lateinit var workingDir: Path
+    private lateinit var mergedManifest: Path
+    private lateinit var partialResultsDir: Path
+    private lateinit var modelsDir: File
 
     @Before
     fun setUp() {
         workingDir = WorkingDirectory(dir = temporaryFolder.newFolder("tmp").toPath()).dir
         lintModelCreator = LintModelCreator()
+        mergedManifest = workingDir.resolve("AndroidManifest.xml").apply { writeText("") }
+        partialResultsDir = workingDir.resolve("partial-results-dir").createDirectories()
+        modelsDir = workingDir.resolve("models-dir").toFile()
     }
 
     @Test
     fun `assert created lint model xmls are parseable by lint model serialization`() {
-        val mergedManifest = workingDir.resolve("AndroidManifest.xml").apply { writeText("") }
-        val partialResultsDir = workingDir.resolve("partial-results-dir").createDirectories()
-        val modelsDir = workingDir.resolve("models-dir").toFile()
         lintModelCreator.create(
             compileSdkVersion = "30",
+            android = true,
             library = false,
             projectName = "//test",
             minSdkVersion = "21",
@@ -59,5 +64,29 @@ class LintModelCreatorTest : BaseTest() {
         assertEquals(partialResultsDir.toFile(), variant.partialResultsDir, "Partial results is parsed")
         assertEquals("com.android.lint", variant.`package`, "Package is parsed") //TODO(arun) Pass from bazel
         assertEquals(listOf("en", "id"), variant.resourceConfigurations, "ResConfigs are parsed")
+    }
+
+    @Test
+    fun `assert create non android library modules don't have sdk versions`() {
+        lintModelCreator.create(
+            compileSdkVersion = "30",
+            android = false,
+            library = false,
+            projectName = "//test",
+            minSdkVersion = "21",
+            targetSdkVersion = "34",
+            mergedManifest = mergedManifest.toFile(),
+            partialResultsDir = partialResultsDir.toFile(),
+            modelsDir = modelsDir,
+            srcs = emptyList(),
+            resources = emptyList(),
+            manifest = null,
+            packageName = "com.android.lint",
+            javaSourceLevel = "1.7",
+            resConfigs = listOf("en", "id")
+        )
+        val variantXml = modelsDir.resolve("main.xml").readText()
+        assertTrue("Does not contain minSdkVersion") { !variantXml.contains("minSdkVersion") }
+        assertTrue("Does not contain targetSdkVersion") { !variantXml.contains("targetSdkVersion") }
     }
 }


### PR DESCRIPTION
https://github.com/grab/grab-bazel-common/pull/156 added support for lint model variant within project.xml, however few values passed to the xml was hardcoded for testing purposes. This PR changes the implementation to pass the values from bazel instead - specifically the aspect passes the values correctly for `android_binary` targets.

`resource_configuration_filters` needs to passed for certain detectors to work, will be followed up with a change in Grazel to generate res config values.