### PR TITLE
Update lint client id to `cli`

### DIFF
--- a/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt
@@ -207,7 +207,7 @@ abstract class LintBaseCommand : CliktCommand() {
             //"--quiet",
             "--exitcode",
             "--offline", // Not a good practice to make bazel actions reach the network yet
-            "--client-id", "test",
+            "--client-id", "cli",
             "--jdk-home", jdkHome // Java home to use
         ).apply {
             System.getenv("ANDROID_HOME")?.let { // TODO(arun) Need to revisit this.


### PR DESCRIPTION
Observed certain detectors are throwing errors when the client id is set to unit test. For [example](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-api/src/main/java/com/android/tools/lint/detector/api/LintFix.kt;l=1786;drc=042516205eef87810ffe9f6d51ba40b1edbb15b0).

As a side effect of this, no of issues detected also increased internally.  