### PR TITLE
Fix lint model cache issues

### DIFF
--- a/tools/lint/src/main/java/com/grab/lint/ProjectXmlCreator.kt
+++ b/tools/lint/src/main/java/com/grab/lint/ProjectXmlCreator.kt
@@ -51,7 +51,7 @@ class ProjectXmlCreator(
         dependencies: List<LintDependency>,
         verbose: Boolean
     ): File {
-        val lintModelsDir = if (modelsDir.exists()) {
+        val lintModelsDir = if (modelsDir.exists() && modelsDir.walk().drop(1).any()) {
             // For android_binary's report step we need to reuse models from analyze action so just return it if it exists
             modelsDir
         } else LintModelCreator().create(


### PR DESCRIPTION
- The current implementation uses existence of modelsDir to check if we reuse or not but just realized that in certain cache scenario it can cause issues due to worker state. It seems we need a similar structure like what we do for projectXml with `createProjectXml`. 

This change is a temp workaround to fix this by checking if directory is not any empty. Will follow up with proper fix later.
