### PR TITLE
Add dedicated flags to determine reusing project xml and models dir in lint reporting action

### DIFF
--- a/rules/android/lint/lint_aspect.bzl
+++ b/rules/android/lint/lint_aspect.bzl
@@ -398,7 +398,8 @@ def _lint_report_action(
         jdk_home = jdk_home,
         verbose = verbose,
     )
-
+    args.add("--no-create-project-xml")
+    args.add("--no-create-models-dir")
     args.add("--updated-baseline", updated_baseline)
     args.add("--fail-on-warning", fail_on_warning)
     args.add("--fail-on-information", fail_on_information)

--- a/tools/lint/src/main/java/com/grab/lint/LintAnalyzeCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintAnalyzeCommand.kt
@@ -17,8 +17,6 @@ class LintAnalyzeCommand : LintBaseCommand() {
         Files.createDirectories(partialResults.toPath())
     }
 
-    override val createProjectXml = true
-
     override fun run(
         workingDir: Path,
         projectXml: File,

--- a/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintBaseCommand.kt
@@ -79,7 +79,7 @@ abstract class LintBaseCommand : CliktCommand() {
     protected val jdkHome by option(
         "-j",
         "--jdk-home",
-        help = "Path fo Java home"
+        help = "Path to Java home"
     ).required()
 
     protected val verbose by option(
@@ -99,6 +99,15 @@ abstract class LintBaseCommand : CliktCommand() {
         help = "Lint models directory containing models.xml"
     ).convert { File(it) }.required()
 
+    private val createModelsDir by option(
+        "-mc",
+        "--create-models-dir",
+        help = "Whether to create a new lint models dir specified via --models-dir"
+    ).flag(
+        "--no-create-models-dir",
+        default = true
+    )
+
     protected val inputBaseline by option(
         "-b",
         "--baseline",
@@ -110,6 +119,15 @@ abstract class LintBaseCommand : CliktCommand() {
         "--project-xml",
         help = "Path to project.xml that will be created/reused when invoking Lint CLI"
     ).convert { File(it) }.required()
+
+    private val createProjectXml by option(
+        "-pc",
+        "--create-project-xml",
+        help = "Whether to create a new project.xml or reuse one specified in --project-xml"
+    ).flag(
+        "--no-create-project-xml",
+        default = true
+    )
 
     private val compileSdkVersion: String by option(
         "-cs",
@@ -161,6 +179,7 @@ abstract class LintBaseCommand : CliktCommand() {
                     minSdkVersion = minSdkVersion,
                     targetSdkVersion = targetSdkVersion,
                     partialResults = partialResults,
+                    createModelsDir = createModelsDir,
                     modelsDir = modelsDir,
                     srcs = srcs,
                     resources = resources,
@@ -192,14 +211,6 @@ abstract class LintBaseCommand : CliktCommand() {
         projectXml: File,
         tmpBaseline: File,
     )
-
-    /**
-     * Create new project.xml at [projectXml].
-     *
-     * Required for non-sandbox modes since we can't rely on file system state when executing in non sandbox modes as previous results might
-     * be still there. When true, a new project XML will be created at [projectXml] and if `false` will use the project xml at this location
-     */
-    abstract val createProjectXml: Boolean
 
     /**
      * Common options for Lint across different types of invocations, analyze or report.

--- a/tools/lint/src/main/java/com/grab/lint/LintReportCommand.kt
+++ b/tools/lint/src/main/java/com/grab/lint/LintReportCommand.kt
@@ -72,8 +72,6 @@ class LintReportCommand : LintBaseCommand() {
         // No-op
     }
 
-    override val createProjectXml: Boolean = false
-
     private fun runLint(workingDir: Path, projectXml: File, tmpBaseline: File, lintResultXml: File) {
         val cliArgs = (defaultLintOptions + listOf(
             "--project", projectXml.toString(),

--- a/tools/lint/src/main/java/com/grab/lint/ProjectXmlCreator.kt
+++ b/tools/lint/src/main/java/com/grab/lint/ProjectXmlCreator.kt
@@ -38,6 +38,7 @@ class ProjectXmlCreator(
         minSdkVersion: String,
         targetSdkVersion: String,
         partialResults: File,
+        createModelsDir: Boolean,
         modelsDir: File,
         srcs: List<String>,
         resources: List<String>,
@@ -51,8 +52,7 @@ class ProjectXmlCreator(
         dependencies: List<LintDependency>,
         verbose: Boolean
     ): File {
-        val lintModelsDir = if (modelsDir.exists() && modelsDir.walk().drop(1).any()) {
-            // For android_binary's report step we need to reuse models from analyze action so just return it if it exists
+        val lintModelsDir = if (!createModelsDir) {
             modelsDir
         } else LintModelCreator().create(
             compileSdkVersion = compileSdkVersion,


### PR DESCRIPTION
Remove hack introduced in https://github.com/grab/grab-bazel-common/pull/168. For reporting, we reuse project.xml and mdoels dir from analyze steps, this PR adds a dedicated flag to differentiate this behavior.