### PR TITLE
Stop depending on `@com_github_jetbrains_kotlin//...` targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ kotlin_test(
     deps = [
         ":binding-adapter-bridge",
         ":binding-adapter-processor",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
         "@maven//:com_github_tschuchortdev_kotlin_compile_testing",
         "@maven//:junit_junit",
     ],

--- a/rules/android/test.bzl
+++ b/rules/android/test.bzl
@@ -56,7 +56,7 @@ def android_unit_test(
         test_runtime_deps = [
             ":" + runtime_resources_name,
             "@grab_bazel_common//rules/android:mock_android_jar",
-            "@com_github_jetbrains_kotlin//:kotlin-reflect",
+            "@maven//:org_jetbrains_kotlin_kotlin_reflect",
         ],
         resources = resources,
         **kwargs

--- a/rules/kotlin/test.bzl
+++ b/rules/kotlin/test.bzl
@@ -29,7 +29,7 @@ def kotlin_test(
         deps = deps,
         test_compile_deps = [],
         test_runtime_deps = [
-            "@com_github_jetbrains_kotlin//:kotlin-reflect",
+            "@maven//:org_jetbrains_kotlin_kotlin_reflect",
         ],
         **kwargs
     )

--- a/rules/test/multi_test.bzl
+++ b/rules/test/multi_test.bzl
@@ -49,7 +49,7 @@ def grab_android_local_test(
         ],
         test_runtime_deps = [
             "@grab_bazel_common//tools/test:mockable-android-jar",
-            "@com_github_jetbrains_kotlin//:kotlin-reflect",
+            "@maven//:org_jetbrains_kotlin_kotlin_reflect",
         ],
         **kwargs
     )
@@ -84,7 +84,7 @@ def grab_kt_jvm_test(
         deps = deps,
         test_compile_deps = [],
         test_runtime_deps = [
-            "@com_github_jetbrains_kotlin//:kotlin-reflect",
+            "@maven//:org_jetbrains_kotlin_kotlin_reflect",
         ],
         **kwargs
     )

--- a/tools/aapt_lite/BUILD
+++ b/tools/aapt_lite/BUILD
@@ -9,7 +9,7 @@ kotlin_test(
         "//tools/aapt_lite/src/main/java/com/grab/aapt",
         "//tools/test_utils",
         "@bazel_common_maven//:junit_junit",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )
 

--- a/tools/binding-adapter-bridge/BUILD.bazel
+++ b/tools/binding-adapter-bridge/BUILD.bazel
@@ -46,6 +46,6 @@ kotlin_test(
         ":binding-adapter-processor",
         "@bazel_common_maven//:com_github_tschuchortdev_kotlin_compile_testing",
         "@bazel_common_maven//:junit_junit",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )

--- a/tools/build_config/BUILD
+++ b/tools/build_config/BUILD
@@ -53,8 +53,8 @@ kotlin_test(
     ],
     deps = [
         ":build-config-sample",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
         "@maven//:junit_junit",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )
 
@@ -75,7 +75,7 @@ kotlin_test(
     ],
     deps = [
         ":build-config-replace-default",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
         "@maven//:junit_junit",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -9,7 +9,7 @@ kotlin_test(
         "//tools/lint/src/main/java/com/grab/lint",
         "//tools/test_utils",
         "@bazel_common_maven//:junit_junit",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )
 

--- a/tools/test_suite_generator/BUILD.bazel
+++ b/tools/test_suite_generator/BUILD.bazel
@@ -39,6 +39,6 @@ kotlin_test(
     deps = [
         ":test_suite_generator",
         "@bazel_common_maven//:junit_junit",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )

--- a/tools/test_suite_generator/README.md
+++ b/tools/test_suite_generator/README.md
@@ -12,22 +12,25 @@ For example, you have a bunch of test classes
 ```kotlin
 class DummyTestClassA {
     @Test
-    fun testFeatureA() {}
+    fun testFeatureA() {
+    }
 }
 
 class DummyTestClassB {
     @Test
-    fun testFeatureB() {}
+    fun testFeatureB() {
+    }
 }
 ```
 
 The generated TestSuite class will look like
 
 ```java
+
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-    DummyTestClassA.class,
-    DummyTestClassB.class
+        DummyTestClassA.class,
+        DummyTestClassB.class
 })
 public class TestSuite {
 }
@@ -40,13 +43,15 @@ You simply add the annotation processor as a dependency for your target. Below i
 ```kotlin
 kt_jvm_test(
     name = "your-test-target",
-    srcs = glob([
-        "..."
-    ]),
+    srcs = glob(
+        [
+            "..."
+        ]
+    ),
     test_class = "com.grazel.generated.TestSuite", // Be aware that the package name is hardcoded
     deps = [
         "@grab_bazel_common//tools/test-info-processor:test-suite-generator",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
         "@maven//:junit_junit",
     ],
 )

--- a/tools/test_utils/BUILD.bazel
+++ b/tools/test_utils/BUILD.bazel
@@ -10,6 +10,6 @@ kotlin_library(
     ],
     deps = [
         "@bazel_common_maven//:junit_junit",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )

--- a/tools/worker/BUILD.bazel
+++ b/tools/worker/BUILD.bazel
@@ -28,6 +28,6 @@ kotlin_test(
     deps = [
         ":worker_lib",
         "@bazel_common_maven//:junit_junit",
-        "@com_github_jetbrains_kotlin//:kotlin-test",
+        "@maven//:org_jetbrains_kotlin_kotlin_test",
     ],
 )

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -1,6 +1,8 @@
 GRAB_BAZEL_COMMON_ARTIFACTS = [
     "org.jetbrains.kotlin:kotlin-parcelize-compiler:1.8.10",
     "org.jetbrains.kotlin:kotlin-parcelize-runtime:1.8.10",
+    "org.jetbrains.kotlin:kotlin-reflect:1.8.10",
+    "org.jetbrains.kotlin:kotlin-test:1.8.10",
     "androidx.compose.compiler:compiler:1.4.3",
     "androidx.annotation:annotation:1.5.0",
     "androidx.databinding:databinding-adapters:7.2.2",


### PR DESCRIPTION
- Instead move them to `@maven` so they are configurable by consuming projects.