### PR TITLE
add lint custom rule inspector

### DIFF
--- a/rules/android/lint/defs.bzl
+++ b/rules/android/lint/defs.bzl
@@ -4,6 +4,7 @@ load(":providers.bzl", _LINT_ENABLED = "LINT_ENABLED")
 load(":lint_test.bzl", _lint_test = "lint_test")
 load(":lint_sources.bzl", _lint_sources = "lint_sources")
 load(":lint_update_baseline.bzl", _lint_update_baseline = "lint_update_baseline")
+load(":lint_inspect.bzl", _lint_inspector = "lint_inspector")
 
 LINT_ENABLED = _LINT_ENABLED
 
@@ -41,4 +42,10 @@ def lint(
         name = name + ".lint_update_baseline",
         target = name + ".lint",
         baseline = lint_baseline,
+    )
+
+    _lint_inspector(
+        name = name + ".lint_inspector",
+        lint_target = name + ".lint",
+        target = name,
     )

--- a/rules/android/lint/lint_aspect.bzl
+++ b/rules/android/lint/lint_aspect.bzl
@@ -4,6 +4,7 @@ load(
     "AarInfo",
     "AarNodeInfo",
     "AndroidLintInfo",
+    "AndroidLintInspectInfo",
     "AndroidLintNodeInfo",
     "AndroidLintSourcesInfo",
     "LINT_ENABLED",
@@ -485,7 +486,7 @@ def _lint_aspect_impl(target, ctx):
 
             aar_node_infos = _aar_node_infos(sources.aars)
             aars = [info.aar for info in aar_node_infos]
-            aars_dir = [info.aar_dir for info in aar_node_infos]
+            aars_dirs = [info.aar_dir for info in aar_node_infos]
 
             # Inputs
             baseline_inputs = []
@@ -536,7 +537,7 @@ def _lint_aspect_impl(target, ctx):
                     sources.srcs +
                     sources.resources +
                     aars +
-                    aars_dir +
+                    aars_dirs +
                     sources.manifest +
                     sources.merged_manifest +
                     [sources.lint_config_xml] +
@@ -588,7 +589,7 @@ def _lint_aspect_impl(target, ctx):
                     sources.srcs +
                     sources.resources +
                     aars +
-                    aars_dir +
+                    aars_dirs +
                     sources.manifest +
                     sources.merged_manifest +
                     [sources.lint_config_xml] +
@@ -609,7 +610,7 @@ def _lint_aspect_impl(target, ctx):
                     lint_result_code_file,
                 ],
             )
-
+            android_lint_inspect_info = AndroidLintInspectInfo(lint_checks = lint_checks, aars_dirs = aars_dirs)
             android_lint_node_info = AndroidLintNodeInfo(
                 name = str(target.label),
                 android = android,
@@ -634,8 +635,14 @@ def _lint_aspect_impl(target, ctx):
                 result_code = None,
                 updated_baseline = None,
             )
+            android_lint_inspect_info = AndroidLintInspectInfo(
+                lint_checks = None,
+                aars_dirs = None,
+            )
+
         return AndroidLintInfo(
             info = android_lint_node_info,
+            inspect_info = android_lint_inspect_info,
             transitive_nodes = depset(
                 [android_lint_node_info],
                 transitive = [depset(transitive = [transitive_lint_node_infos])],

--- a/rules/android/lint/lint_inspect.bzl
+++ b/rules/android/lint/lint_inspect.bzl
@@ -1,0 +1,78 @@
+load("@grab_bazel_common//rules/android/lint:providers.bzl", "AndroidLintInfo")
+load("@grab_bazel_common//rules/android:utils.bzl", "utils")
+
+def _lint_inspector(ctx):
+    lint_target = ctx.attr.lint_target
+    target = ctx.attr.target
+
+    lint_checks = ctx.attr.lint_target[AndroidLintInfo].inspect_info.lint_checks
+    aars_dirs = ctx.attr.lint_target[AndroidLintInfo].inspect_info.aars_dirs
+
+    executable = ctx.actions.declare_file("lint/%s_inspect.sh" % target.label.name)
+    lint_rules = ctx.actions.declare_file("lint/%s_lint_rules.json" % target.label.name)
+
+    ctx.actions.write(
+        output = executable,
+        content = """
+                    #!/bin/bash
+                    echo "\nlint_rules: $(realpath {lint_rules})"
+                            """.format(
+            lint_rules = lint_rules.short_path,
+        ),
+    )
+
+    mnemonic = "AndroidLintInspector"
+    args = ctx.actions.args()
+
+    args.add_joined(
+        "--aars-dirs",
+        aars_dirs,
+        join_with = ",",
+        map_each = utils.to_path,
+    )
+    args.add_joined(
+        "--lint-checks",
+        lint_checks,
+        join_with = ",",
+        map_each = utils.to_path,
+    )
+    args.add("--output", lint_rules.path)
+
+    ctx.actions.run(
+        mnemonic = mnemonic,
+        inputs = depset(
+            lint_checks + aars_dirs,
+        ),
+        outputs = [lint_rules],
+        executable = ctx.executable._lint_inspector_cli,
+        arguments = [args],
+        progress_message = "%s %s" % (mnemonic, str(ctx.label).lstrip("@")),
+    )
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles(files = [lint_rules]),
+            files = depset([lint_rules]),
+        ),
+    ]
+
+lint_inspector = rule(
+    implementation = _lint_inspector,
+    executable = True,
+    attrs = {
+        "_lint_inspector_cli": attr.label(
+            executable = True,
+            cfg = "exec",
+            default = Label("//tools/lint:lint_inspector"),
+        ),
+        "target": attr.label(
+            doc = "name of the android/kotlin/java target",
+        ),
+        "lint_target": attr.label(
+            doc = "The lint target to inspect",
+            providers = [AndroidLintInfo],
+            mandatory = True,
+        ),
+    },
+)

--- a/rules/android/lint/providers.bzl
+++ b/rules/android/lint/providers.bzl
@@ -17,6 +17,7 @@ AndroidLintNodeInfo = provider(
 AndroidLintInfo = provider(
     doc = "Provider containing info about lint on this target and it's dependencies",
     fields = dict(
+        inspect_info = "AndroidLintInspectInfo containing lint checks jars and aars directories that have custom lint checks",
         info = "AndroidLintNodeInfo containing data about Android Lint",
         transitive_nodes = "Depset of AndroidLintNodeInfo containing data about dependencies' lint",
     ),
@@ -44,6 +45,14 @@ AarNodeInfo = provider(
         "aar": "aar path",
         "aar_dir": "aar extracrted path",
     },
+)
+
+AndroidLintInspectInfo = provider(
+    doc = "AndroidLintInspectInfo containing lint checks jars and aars directories that have custom lint checks",
+    fields = dict(
+        lint_checks = "custom lint checks jar files",
+        aars_dirs = "path to extracted aar direcotries containing lint rules",
+    ),
 )
 
 AarInfo = provider(

--- a/rules/android/utils.bzl
+++ b/rules/android/utils.bzl
@@ -16,8 +16,12 @@ def _collect_providers(provider_type, *all_deps):
                 providers.append(dep[provider_type])
     return providers
 
+def _to_depset(list):
+    return depset(list)
+
 utils = struct(
     to_path = _to_path,
     inspect = _inspect,
     collect_providers = _collect_providers,
+    to_depset = _to_depset,
 )

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -23,3 +23,16 @@ java_binary(
         "//tools/lint/src/main/java/com/grab/lint",
     ],
 )
+
+java_binary(
+    name = "lint_inspector",
+    #    jvm_flags = ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"],
+    main_class = "com.grab.lint.inspector.MainKt",
+    visibility = [
+        "//visibility:public",
+    ],
+    runtime_deps = [
+        "//tools/lint/src/main/java/com/grab/lint/inspector:lint-inspector-lib",
+    ],
+    #
+)

--- a/tools/lint/src/main/java/com/grab/lint/inspector/ArgumentParser.kt
+++ b/tools/lint/src/main/java/com/grab/lint/inspector/ArgumentParser.kt
@@ -1,0 +1,33 @@
+package com.grab.lint.inspector
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import java.io.File
+
+class ArgumentParser : CliktCommand() {
+
+    private val outPut by option(
+        "-o",
+        "--output",
+        help = "a json file result that contains custom lint rules infos"
+    ).convert { File(it) }.required()
+
+    private val lintChecks by option(
+        "-lc",
+        "--lint-checks",
+        help = "jar files that contains custom lint checks"
+    ).convert { it.split(",").map { File(it) } }.default(emptyList())
+
+    private val aarDeps by option(
+        "-ad",
+        "--aars-dirs",
+        help = "aars extract directories that contains custom lint checks"
+    ).convert { it.split(",").map { File(it) }.filter { it.name == "lint.jar" } }.default(emptyList())
+
+    override fun run() {
+        Inspector(outPut, lintChecks, aarDeps).run()
+    }
+}

--- a/tools/lint/src/main/java/com/grab/lint/inspector/BUILD.bazel
+++ b/tools/lint/src/main/java/com/grab/lint/inspector/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@grab_bazel_common//rules:defs.bzl", "kotlin_library")
 
 kotlin_library(
-    name = "lint",
+    name = "lint-inspector-lib",
     srcs = glob([
         "*.kt",
     ]),
@@ -9,12 +9,11 @@ kotlin_library(
         "//visibility:public",
     ],
     deps = [
-        "//:dagger",
-        "//tools/cli_utils",
-        "//tools/worker:worker_lib",
-        "@bazel_common_maven//:com_android_tools_lint_lint",
         "@bazel_common_maven//:com_android_tools_lint_lint_api",
         "@bazel_common_maven//:com_android_tools_lint_lint_checks",
         "@bazel_common_maven//:com_github_ajalt_clikt",
+        "@bazel_common_maven//:com_squareup_moshi_moshi_kotlin",
+        "@bazel_common_maven//:net_sf_kxml_kxml2",
+        "@bazel_common_maven//:xmlpull_xmlpull",
     ],
 )

--- a/tools/lint/src/main/java/com/grab/lint/inspector/Inspector.kt
+++ b/tools/lint/src/main/java/com/grab/lint/inspector/Inspector.kt
@@ -1,0 +1,176 @@
+package com.grab.lint.inspector
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.LintClient
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Severity
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.io.File
+import java.io.InputStreamReader
+import java.net.MalformedURLException
+import java.net.URL
+import java.net.URLClassLoader
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+
+/**
+ * Inspect the lint checks from the given jars and aar dependencies
+ * adapted from https://android.googlesource.com/platform/tools/base/+/studio-master-dev/lint/libs/lint-api/src/main/java/com/android/tools/lint/client/api/JarFileIssueRegistry.kt
+ */
+class Inspector(
+    private val outPut: File,
+    private val lintChecks: List<File>,
+    private val aarDeps: List<File>
+) {
+    private val issueAdapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(Array<LintCheckModel>::class.java)
+
+    fun run() {
+        println(
+            """
+            ************ Lint Inspector Jars ************
+            lintChecks: 
+            ${lintChecks.joinToString { it.path + "\n" }} 
+        """.trimIndent()
+        )
+        println(
+            """
+            aarDeps: 
+            ${aarDeps.joinToString { it.path + "\n" }}
+            ************** End **************
+        """.trimIndent()
+        )
+
+        outPut.parentFile?.mkdirs()
+        outPut.createNewFile()
+
+        outPut.writeText(
+            issueAdapter.toJson(
+                (lintChecks + aarDeps).loadIssues().map { (jar, issues) ->
+                    LintCheckModel.fromJar(jar, issues)
+                }.toTypedArray()
+            )
+        )
+    }
+
+    fun List<File>.loadIssues(): List<Pair<String, List<Issue>>> {
+        val registeredIssues = map { jarFile ->
+            val registry = findRegistries(jarFile)
+            if (registry != null) {
+                jarFile.path to registeredIssues(jarFile, registry)
+            } else {
+                jarFile.path to emptyList()
+            }
+        }
+
+        registeredIssues.forEachIndexed { index, it ->
+            println("lint jarFile=$index ${it.first}")
+            it.second.forEachIndexed { index, issue ->
+                println("Issue: $index ${issue.id} ${issue}")
+            }
+        }
+
+        return registeredIssues
+    }
+
+    private fun registeredIssues(jarFile: File, className: String): List<Issue> {
+        LintClient.clientName = "jarClassLoader"
+        val loader =
+            createUrlClassLoader(listOf(jarFile), ArgumentParser::class.java.classLoader)
+        val registryClass = Class.forName(className, true, loader)
+        val registry = registryClass.getDeclaredConstructor().newInstance() as IssueRegistry
+        val issues =
+            try {
+                registry.issues
+            } catch (e: Throwable) {
+                e.printStackTrace()
+                emptyList()
+            }
+
+        return issues
+    }
+
+    private val SERVICE_KEY = "META-INF/services/com.android.tools.lint.client.api.IssueRegistry"
+    private val MF_LINT_REGISTRY = "Lint-Registry-v2"
+    private val MF_LINT_REGISTRY_OLD = "Lint-Registry"
+
+    private fun findRegistries(jarFile: File): String? {
+        if (jarFile.exists().not()) {
+            throw IllegalArgumentException("File not found: ${jarFile.absolutePath}")
+        }
+        JarFile(jarFile).use { file ->
+            val manifest = file.manifest
+            if (manifest != null) {
+                val attrs = manifest.mainAttributes
+                var attribute: Any? = attrs[Attributes.Name(MF_LINT_REGISTRY)]
+                var isLegacy = false
+                if (attribute == null) {
+                    attribute = attrs[Attributes.Name(MF_LINT_REGISTRY_OLD)]
+                    if (attribute != null) {
+                        isLegacy = true
+                    }
+                }
+                if (attribute is String) {
+                    val className = attribute
+
+                    // Store class name -- but it may not be unique (there could be
+                    // multiple separate jar files pointing to the same issue registry
+                    // (due to the way local lint.jar files propagate via project
+                    // dependencies) so only store this file if it hasn't already
+                    // been found, or if it's a v2 version (e.g. not legacy)
+                    if (!isLegacy) {
+                        return className
+                    }
+                    return@use
+                }
+            }
+
+            // Load service keys. We're reading it manually instead of using
+            // ServiceLoader because we don't want to put these jars into
+            // the class loaders yet (since there can be many duplicates
+            // when a library is available through multiple dependencies)
+            val services = file.getJarEntry(SERVICE_KEY)
+            if (services != null) {
+                file.getInputStream(services).use {
+                    val reader = InputStreamReader(it, Charsets.UTF_8)
+                    reader.useLines { lines ->
+                        for (line in lines) {
+                            val comment = line.indexOf("#")
+                            val className =
+                                if (comment >= 0) {
+                                    line.substring(0, comment).trim()
+                                } else {
+                                    line.trim()
+                                }
+                            if (className.isNotEmpty()) {
+                                return className
+                            }
+                        }
+                    }
+                }
+            } else if (jarFile.name == "lint.jar") {
+                println(
+                    Severity.ERROR.toString() + ":" +
+                            null + ":" +
+                            "Custom lint rule jar %1\$s does not contain a valid " +
+                            "registry manifest key (%2\$s).\n" +
+                            "Either the custom jar is invalid, or it uses an outdated " +
+                            "API not supported this lint client" + ":" +
+                            jarFile.path + ":"
+                )
+            }
+        }
+        return null
+    }
+
+    private fun createUrlClassLoader(files: List<File>, parent: ClassLoader): ClassLoader =
+        URLClassLoader(files.mapNotNull { fileToUrl(it) }.toTypedArray(), parent)
+
+    @Throws(MalformedURLException::class)
+    private fun fileToUrl(file: File): URL {
+        return file.toURI().toURL()
+    }
+}

--- a/tools/lint/src/main/java/com/grab/lint/inspector/LintIssueModel.kt
+++ b/tools/lint/src/main/java/com/grab/lint/inspector/LintIssueModel.kt
@@ -1,0 +1,38 @@
+package com.grab.lint.inspector
+
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.TextFormat
+
+data class LintCheckModel(
+    val jar:String,
+    val issues: List<LintIssueModel>
+){
+    companion object {
+        fun fromJar(jar: String, issues: List<Issue>): LintCheckModel {
+            return LintCheckModel(
+                jar,
+                issues.map { it.toLintIssueModel() }
+            )
+        }
+    }
+}
+
+data class LintIssueModel(
+    val id: String,
+    val category: String,
+    val priority: Int,
+    val Severity: String,
+    val enabledByDefault: Boolean,
+    val briefDescription: String,
+)
+
+fun Issue.toLintIssueModel(): LintIssueModel {
+    return LintIssueModel(
+        this.id,
+        this.category.name,
+        this.priority,
+        this.defaultSeverity.name,
+        this.isEnabledByDefault(),
+        this.getBriefDescription(TextFormat.RAW),
+    )
+}

--- a/tools/lint/src/main/java/com/grab/lint/inspector/Main.kt
+++ b/tools/lint/src/main/java/com/grab/lint/inspector/Main.kt
@@ -1,0 +1,5 @@
+package com.grab.lint.inspector
+
+fun main(args: Array<String>) {
+    ArgumentParser().main(args)
+}


### PR DESCRIPTION
This utility tool helps you inspect which lint rules are applied to each target. Since lint rules can be indirectly applied to targets through AAR dependencies, it's beneficial to know exactly which rules are in effect for each target. This tool generates a JSON file that lists all the rules, provides detailed information about them, and indicates their source.

`bazelisk run target_name.lint_inspector `