### PR TITLE
Remove restriction in custom_res against top-level directory

### DIFF
--- a/tools/custom_res/custom_res.bzl
+++ b/tools/custom_res/custom_res.bzl
@@ -23,7 +23,7 @@ def custom_res(target, dir_name, resource_files = []):
     new_root_dir = target + "_" + dir_name
     fixed_resource_path = []
     for old_resource_path in resource_files:
-        fixed_path = new_root_dir + "/" + old_resource_path.replace("/" + dir_name, "/res")
+        fixed_path = new_root_dir + "/" + old_resource_path.replace(dir_name + "/", "res/")
         fixed_resource_path.append(fixed_path)
         genrule_suffix = old_resource_path.replace("/", "_").replace(".", "_").replace("-", "_")
         native.genrule(


### PR DESCRIPTION
Currently, custom_res rule enforces that dir_name is not in the same directory as the package. It does this implicitly:

```
old_resource_path.replace("/" + dir_name, "/res")
```

This means that if `"/" + dir_name` does not exist in the resource path, nothing will be replaced, and the rule fails. Meaning that, for instance:

```
.
├── BUILD.bazel
├── res
├── res-debug
└── res-release
```

This fails, because the resource path is `res-debug/values/example.xml`.

By the nature of the rule, the resource paths having dir_name plus a slash at the end feels more correct to enforce than starting with a slash.