### PR TITLE
Integrate `bazel_rules_detekt` 

### DIFF
--- a/rules/android/android_binary.bzl
+++ b/rules/android/android_binary.bzl
@@ -2,6 +2,7 @@ load("@grab_bazel_common//tools/build_config:build_config.bzl", _build_config = 
 load("@grab_bazel_common//tools/kotlin:android.bzl", "kt_android_library")
 load("@grab_bazel_common//rules/android/databinding:databinding.bzl", "DATABINDING_DEPS")
 load("@grab_bazel_common//rules/android/lint:defs.bzl", "LINT_ENABLED", "lint", "lint_sources", _lint_baseline = "baseline")
+load("@grab_bazel_common//rules/check/detekt:defs.bzl", "detekt")
 load(":resources.bzl", "build_resources")
 
 def android_binary(
@@ -13,6 +14,7 @@ def android_binary(
         enable_data_binding = False,
         enable_compose = False,
         lint_options = {},
+        detekt_options = {},
         **attrs):
     """
     `android_binary` wrapper that setups a native.android_binary with various customizations
@@ -26,6 +28,7 @@ def android_binary(
                  resource for `android_binary`.
       custom_package: The package name for android_binary, must be same as one declared in AndroidManifest.xml
       lint_options: Lint options to pass to lint, typically contains baselines and config.xml
+      detekt_options: detekt options to pass to detekt, typically contains baselines and config.yml
       enable_data_binding: Enable android databinding support for this target
       enable_compose: Enable Jetpack Compose support for this target
       **attrs: Additional attrs to pass to generated android_binary.
@@ -93,6 +96,20 @@ def android_binary(
             name = name,
             linting_target = name,
             lint_baseline = lint_baseline,
+        )
+
+    if (detekt_options.get("enabled", False) and len(attrs.get("srcs", default = [])) > 0):
+        detekt(
+            name = name,
+            baseline = detekt_options.get("baseline", None),
+            cfgs = detekt_options.get("config", None),
+            srcs = attrs.get("srcs", default = []),
+            parallel = detekt_options.get("parallel", default = False),
+            all_rules = detekt_options.get("all_rules", default = False),
+            build_upon_default_config = detekt_options.get("build_upon_default_config", default = False),
+            disable_default_rule_sets = detekt_options.get("disable_default_rule_sets", default = False),
+            auto_correct = detekt_options.get("auto_correct", default = False),
+            detekt_checks = detekt_options.get("detekt_checks", default = []),
         )
 
     if enable_data_binding:

--- a/rules/android/android_library.bzl
+++ b/rules/android/android_library.bzl
@@ -3,6 +3,7 @@ load("@grab_bazel_common//tools/kotlin:android.bzl", "kt_android_library")
 load("@grab_bazel_common//rules/android/databinding:databinding.bzl", "kt_db_android_library")
 load(":resources.bzl", "build_resources")
 load("@grab_bazel_common//rules/android/lint:defs.bzl", "LINT_ENABLED", "lint", "lint_sources")
+load("@grab_bazel_common//rules/check/detekt:defs.bzl", "detekt")
 
 def android_library(
         name,
@@ -14,6 +15,7 @@ def android_library(
         enable_data_binding = False,
         enable_compose = False,
         lint_options = {},
+        detekt_options = {},
         **attrs):
     """
     `android_binary` wrapper that setups a native.android_binary with various customizations
@@ -76,6 +78,20 @@ def android_library(
             lint_baseline = lint_baseline,
         )
         tags = tags + [LINT_ENABLED]
+
+    if (detekt_options.get("enabled", False) and len(srcs) > 0):
+        detekt(
+            name = name,
+            baseline = detekt_options.get("baseline", None),
+            cfgs = detekt_options.get("config", None),
+            srcs = srcs,
+            parallel = detekt_options.get("parallel", default = False),
+            all_rules = detekt_options.get("all_rules", default = False),
+            build_upon_default_config = detekt_options.get("build_upon_default_config", default = False),
+            disable_default_rule_sets = detekt_options.get("disable_default_rule_sets", default = False),
+            auto_correct = detekt_options.get("auto_correct", default = False),
+            detekt_checks = detekt_options.get("detekt_checks", default = []),
+        )
 
     if enable_compose:
         android_library_deps.extend(["@grab_bazel_common//rules/android/compose:compose-plugin"])

--- a/rules/check/detekt/defs.bzl
+++ b/rules/check/detekt/defs.bzl
@@ -1,0 +1,81 @@
+load("@rules_detekt//detekt:defs.bzl", _detekt_create_baseline = "detekt_create_baseline", _detekt_test = "detekt_test")
+load("@grab_bazel_common//rules/android/lint:utils.bzl", _baseline_validator = "baseline")
+
+def detekt(
+        name,
+        baseline,
+        cfgs,
+        srcs,
+        parallel,
+        all_rules,
+        build_upon_default_config,
+        disable_default_rule_sets,
+        auto_correct,
+        detekt_checks):
+    #    TODO: Add more documentation
+    """Runs detekt on the target
+
+    Run bazelisk test <name>.detekt_test to run Detekt lint on the target and produce the result XML
+    Run baselisk run <name>.detekt_update_baseline to update the baseline for use with detekt
+
+    Args:
+      name: The name of the detekt target
+      baseline: The baseline XML file to compare results against
+      cfgs: The config XML file to configure detekt
+      srcs: input sources to run detekt on
+      plugins: The plugins to run detekt with/ custom detekt rules
+      parallel: [https://detekt.dev/docs/gettingstarted/cli/]
+      all_rules: [https://detekt.dev/docs/gettingstarted/cli/]
+      build_upon_default_config: [https://detekt.dev/docs/gettingstarted/cli/]
+      disable_default_rule_sets: [https://detekt.dev/docs/gettingstarted/cli/]
+      auto_correct: [https://detekt.dev/docs/gettingstarted/cli/]
+      //todo enable class path for detekt
+    """
+
+    _detekt_test(
+        name = name + ".detekt_test",
+        baseline = baseline,
+        cfgs = cfgs,
+        srcs = srcs,
+        parallel = parallel,
+        all_rules = all_rules,
+        build_upon_default_config = build_upon_default_config,
+        disable_default_rule_sets = disable_default_rule_sets,
+        auto_correct = auto_correct,
+        plugins = detekt_checks,
+    )
+
+    _detekt_create_baseline(
+        name = name + ".detekt_update_baseline",
+        baseline = baseline,
+        cfgs = cfgs,
+        srcs = srcs,
+        parallel = parallel,
+        all_rules = all_rules,
+        build_upon_default_config = build_upon_default_config,
+        disable_default_rule_sets = disable_default_rule_sets,
+        auto_correct = auto_correct,
+        plugins = detekt_checks,
+    )
+
+def detekt_options(
+        enabled,
+        baseline = None,
+        cfgs = [],
+        parallel = False,
+        all_rules = False,
+        build_upon_default_config = False,
+        disable_default_rule_sets = False,
+        auto_correct = False,
+        detekt_checks = []):
+    return {
+        "enabled": enabled,
+        "baseline": baseline,
+        "cfgs": cfgs,
+        "parallel": parallel,
+        "all_rules": all_rules,
+        "build_upon_default_config": build_upon_default_config,
+        "disable_default_rule_sets": disable_default_rule_sets,
+        "auto_correct": auto_correct,
+        "detekt_checks": detekt_checks,
+    }

--- a/rules/defs.bzl
+++ b/rules/defs.bzl
@@ -1,5 +1,6 @@
 load("@grab_bazel_common//rules/android:android_binary.bzl", _android_binary = "android_binary")
 load("@grab_bazel_common//rules/android:android_library.bzl", _android_library = "android_library")
+load("@grab_bazel_common//rules/check/detekt:defs.bzl", _detekt_options = "detekt_options")
 load("@grab_bazel_common//rules/android:android_instrumentation.bzl", _android_instrumentation_binary = "android_instrumentation_binary")
 load("@grab_bazel_common//rules/android:test.bzl", _android_unit_test = "android_unit_test")
 load(
@@ -19,3 +20,4 @@ android_unit_test = _android_unit_test
 kotlin_library = _kt_jvm_library_interal
 kt_compiler_plugin = _kt_compiler_plugin
 kotlin_test = _kotlin_test
+detekt_options = _detekt_options

--- a/rules/kotlin/kotlin.bzl
+++ b/rules/kotlin/kotlin.bzl
@@ -2,6 +2,7 @@ load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", _kt_jvm_library = "kt_jvm_library
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", _kt_compiler_plugin = "kt_compiler_plugin")
 load("@grab_bazel_common//rules/android/lint:defs.bzl", "lint", "lint_sources")
 load("@grab_bazel_common//rules/android/lint:providers.bzl", "LINT_ENABLED")
+load("@grab_bazel_common//rules/check/detekt:defs.bzl", "detekt")
 
 kt_jvm_library = _kt_jvm_library
 kt_compiler_plugin = _kt_compiler_plugin
@@ -10,6 +11,7 @@ def kt_jvm_library_interal(
         name,
         exec_properties = None,
         lint_options = {},
+        detekt_options = {},
         **attrs):
     srcs = attrs.get("srcs", default = [])
     lint_sources_target = "_" + name + "_lint_sources"
@@ -38,6 +40,20 @@ def kt_jvm_library_interal(
 
         attrs["deps"] = deps
         attrs["tags"] = tags
+
+    if (detekt_options.get("enabled", False) and len(srcs) > 0):
+        detekt(
+            name = name,
+            baseline = detekt_options.get("baseline", None),
+            cfgs = detekt_options.get("config", None),
+            srcs = srcs,
+            parallel = detekt_options.get("parallel", default = False),
+            all_rules = detekt_options.get("all_rules", default = False),
+            build_upon_default_config = detekt_options.get("build_upon_default_config", default = False),
+            disable_default_rule_sets = detekt_options.get("disable_default_rule_sets", default = False),
+            auto_correct = detekt_options.get("auto_correct", default = False),
+            detekt_checks = detekt_options.get("detekt_checks", default = []),
+        )
 
     kt_jvm_library(
         name = name,

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -37,6 +37,18 @@ def _kotlin():
         urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin_release.tgz" % RULES_KOTLIN_VERSION],
     )
 
+def _detekt():
+    rules_detekt_version = "0.8.1.4"
+
+    rules_detekt_sha = "95640b50bbb4d196ad00cce7455f6033f2a262aa56ac502b559160ca7ca84e3f"
+
+    http_archive(
+        name = "rules_detekt",
+        sha256 = rules_detekt_sha,
+        strip_prefix = "bazel_rules_detekt-{v}".format(v = rules_detekt_version),
+        url = "https://github.com/mohammadkahelghi-grabtaxi/bazel_rules_detekt/releases/download/v{v}/bazel_rules_detekt-v{v}.tar.gz".format(v = rules_detekt_version),
+    )
+
 def _proto():
     http_archive(
         name = "com_google_protobuf",
@@ -70,3 +82,4 @@ def bazel_common_dependencies():
     #_proto
     _maven()
     _kotlin()
+    _detekt()

--- a/rules/setup.bzl
+++ b/rules/setup.bzl
@@ -17,6 +17,10 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 # Kotlin
 load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version")
 
+#Detekt
+load("@rules_detekt//detekt:dependencies.bzl", "rules_detekt_dependencies")
+load("@rules_detekt//detekt:toolchains.bzl", "rules_detekt_toolchains")
+
 # Proto
 # load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
@@ -97,3 +101,7 @@ def bazel_common_setup(
 
     _android(patched_android_tools)
     _kotlin()
+
+    rules_detekt_dependencies()
+
+    rules_detekt_toolchains()

--- a/tests/android/library/BUILD.bazel
+++ b/tests/android/library/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@grab_bazel_common//rules:defs.bzl", "android_library", "android_unit_test")
+load("@grab_bazel_common//rules:defs.bzl", "android_library", "android_unit_test", "detekt_options")
 
 android_library(
     name = "android_library_sample",
@@ -6,6 +6,10 @@ android_library(
         "src/main/java/**/*.kt",
     ]),
     custom_package = "com.grab.test.lib",
+    detekt_options = detekt_options(
+        baseline = "detekt_baseline.xml",
+        enabled = True,
+    ),
     enable_data_binding = True,
     lint_options = {
         "enabled": True,

--- a/tests/android/library/detekt_baseline.xml
+++ b/tests/android/library/detekt_baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>EmptyFunctionBlock:LibraryActivity.kt$LibraryActivity${ }</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/tests/android/library/src/main/java/com/grab/test/LibraryActivity.kt
+++ b/tests/android/library/src/main/java/com/grab/test/LibraryActivity.kt
@@ -2,4 +2,10 @@ package com.grab.test
 
 import android.app.Activity
 
-class LibraryActivity : Activity()
+class LibraryActivity : Activity(){
+
+    fun x(){
+
+    }
+
+}


### PR DESCRIPTION
adapting detekt 

To run Detekt checks on the target and produce the result XML, Run 
`bazelisk test <name>.detekt_test `
To update the baseline, Run 
`baselisk run <name>.detekt_update_baseline `