### PR TITLE
Handle empty assets and res directories

### DIFF
--- a/tools/aapt_lite/src/main/java/com/google/devtools/build/android/ResourceMerger.java
+++ b/tools/aapt_lite/src/main/java/com/google/devtools/build/android/ResourceMerger.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 public class ResourceMerger {
     private static final StdLogger STD_LOGGER = new StdLogger(StdLogger.Level.WARNING);
 
@@ -37,10 +39,12 @@ public class ResourceMerger {
 
     public static void merge(final boolean isBinary,
                              final List<SourceSet> sourceSets,
-                             final File outputDir,
+                             @Nullable final File outputDir,
                              final File mergeManifest) throws IOException {
         mergeManifests(isBinary, sourceSets, mergeManifest);
-        mergeResources(sourceSets, outputDir, mergeManifest);
+        if (outputDir != null) {
+            mergeResources(sourceSets, outputDir, mergeManifest);
+        }
     }
 
     private static void mergeResources(final List<SourceSet> sourceSets, final File outputDir, final File manifest) throws IOException {

--- a/tools/aapt_lite/src/main/java/com/google/devtools/build/android/ResourceMergerCommand.kt
+++ b/tools/aapt_lite/src/main/java/com/google/devtools/build/android/ResourceMergerCommand.kt
@@ -58,17 +58,19 @@ class ResourceMergerCommand : CliktCommand() {
 
     override fun run() {
         val sourceSets = sourceSets.map { arg -> SourceSet.from(target, arg) }
-        val outputPath = commonPath(*outputs.toTypedArray()).split("/res/").first()
-        val outputDir = File(outputPath).apply {
-            deleteRecursively()
-            parentFile?.mkdirs()
-        }
+        val outputDir = if (outputs.isNotEmpty()) {
+            val outputPath = commonPath(*outputs.toTypedArray()).split("/res/").first()
+            File(outputPath).apply {
+                deleteRecursively()
+                parentFile?.mkdirs()
+            }
+        } else null
         ResourceMerger.merge(
             /* isBinary = */ binary,
             /* sourceSets = */ sourceSets,
             /* outputDir = */ outputDir,
             /* mergeManifest = */ mergedManifestOutput
         )
-        OutputFixer.process(outputDir = outputDir, declaredOutputs = outputs)
+        outputDir?.let { OutputFixer.process(outputDir = it, declaredOutputs = outputs) }
     }
 }


### PR DESCRIPTION
Handle cases where a source set only contains a manifest and does not contain any res or assets. In that case there will be no merged output and the tool only has to do manifest merging.