### PR TITLE
Handle resource duplicates in resource merger

### DIFF
--- a/rules/android/resources.bzl
+++ b/rules/android/resources.bzl
@@ -1,3 +1,4 @@
+load("@grab_bazel_common//rules/android:utils.bzl", "utils")
 load("@grab_bazel_common//rules/android/private:resource_merger.bzl", "resource_merger")
 load("@grab_bazel_common//tools/res_value:res_value.bzl", "res_value")
 
@@ -144,6 +145,8 @@ def build_resources(
                 source_sets.append("%s:%s:%s" % (resource_dir, asset_dir, manifest))
 
             merge_target_name = "_" + name + "_res"
+            all_resources = utils.to_set(all_resources)
+            all_assets = utils.to_set(all_assets)
             merged_resources = _calculate_output_files(merge_target_name, all_resources)
             merged_assets = _calculate_output_files(merge_target_name, all_assets)
 

--- a/rules/android/utils.bzl
+++ b/rules/android/utils.bzl
@@ -19,9 +19,16 @@ def _collect_providers(provider_type, *all_deps):
 def _to_depset(list):
     return depset(list)
 
+def _to_set(items):
+    value_dict = {}
+    for item in items:
+        value_dict[item] = item
+    return list(value_dict.values())
+
 utils = struct(
     to_path = _to_path,
     inspect = _inspect,
     collect_providers = _collect_providers,
     to_depset = _to_depset,
+    to_set = _to_set,
 )


### PR DESCRIPTION
Due to configuration issues if there are multiple res directories with same files, ensure the list is deduped before passing to `resource_merger` rule.