### PR TITLE
Fix error reproduced by adding `--incompatible_disallow_empty_glob`

### DIFF
--- a/tools/worker/BUILD.bazel
+++ b/tools/worker/BUILD.bazel
@@ -5,7 +5,6 @@ kotlin_library(
     name = "worker_lib",
     srcs = glob([
         "src/main/kotlin/**/*.kt",
-        "src/main/kotlin/**/*.java",
     ]),
     visibility = [
         "//visibility:public",


### PR DESCRIPTION
There are no .java files in this tree, so it can be removed.