### PR TITLE
Enable Jetpack Compose Strong Skipping Mode

### DIFF
--- a/rules/android/compose/BUILD.bazel
+++ b/rules/android/compose/BUILD.bazel
@@ -2,7 +2,10 @@ load("@grab_bazel_common//rules:defs.bzl", "kotlin_library", "kt_compiler_plugin
 
 kt_compiler_plugin(
     name = "compose-compiler-plugin",
-    id = "androidx.compose.compiler",
+    id = "androidx.compose.compiler.plugins.kotlin",
+    options = {
+        "experimentalStrongSkipping": "true",
+    },
     target_embedded_compiler = True,
     deps = [
         "@maven//:androidx_compose_compiler_compiler",


### PR DESCRIPTION
Enable Jetpack Compose Strong skipping mode.
We need to update the ID because, behind the scenes, kt_compiler_plugin will pass the parameter in this format
`-P plugin:<plugin_id>:<key>=<value>`