### PR TITLE
Bazel 8 Migration - Workspace Reordering & Patches Registration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,9 @@ workspace(name = "grab_bazel_common")
 load("@grab_bazel_common//rules:repositories.bzl", "bazel_common_dependencies")
 bazel_common_dependencies()
 
-# rules_android necessary setup
-# has to be in WORKSPACE to avoid compatibility_proxy issue (eager load issue)
-load("@rules_android//:prereqs.bzl", "rules_android_prereqs")
-rules_android_prereqs()
-load("@bazel_features//:deps.bzl", "bazel_features_deps")
-bazel_features_deps()
+load("@grab_bazel_common//rules:prereqs.bzl", "bazel_common_prereqs")
+bazel_common_prereqs()
+
 load("@rules_cc//cc:extensions.bzl", "compatibility_proxy_repo")
 compatibility_proxy_repo()
 load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
@@ -17,6 +14,7 @@ load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_baze
 proto_bazel_features(name = "proto_bazel_features")
 load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
 rules_java_toolchains()
+
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 rules_jvm_external_deps()
 load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")

--- a/patches/rules_android/BUILD.bazel
+++ b/patches/rules_android/BUILD.bazel
@@ -1,5 +1,9 @@
 exports_files([
     "macos_cp_reflink.patch", 
     "guava_version.patch",
+    "databinding_androidx_flag.patch",
+    "databinding_annotation_template.patch",
+    "databinding_prefixes.patch",
+    "databinding_processor_absolute_path.patch",
     ]
 )

--- a/rules/prereqs.bzl
+++ b/rules/prereqs.bzl
@@ -1,0 +1,20 @@
+load("@rules_android//:prereqs.bzl", "rules_android_prereqs")
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+load("//android/tools:defs.bzl", "android_tools")
+
+def bazel_common_prereqs(patched_android_tools = True):
+    """Downloads transitive dependencies and sets up android_tools.
+
+    Must be called after bazel_common_dependencies() and before bazel_common_setup().
+
+    Args:
+        patched_android_tools: If True (default), registers patched @android_tools
+            with databinding 7.1.0 before rules_android_prereqs(). If False,
+            rules_android_prereqs() downloads the default @android_tools.
+    """
+    if patched_android_tools:
+        # Patched android_tools MUST be before rules_android_prereqs() so maybe() in
+        # prereqs.bzl sees existing @android_tools and skips the default one.
+        android_tools()
+    rules_android_prereqs()
+    bazel_features_deps()

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -16,6 +16,8 @@ def _android():
             "@grab_bazel_common//patches/rules_android:guava_version.patch",
             "@grab_bazel_common//patches/rules_android:databinding_annotation_template.patch",
             "@grab_bazel_common//patches/rules_android:databinding_androidx_flag.patch",
+            "@grab_bazel_common//patches/rules_android:databinding_prefixes.patch",
+            "@grab_bazel_common//patches/rules_android:databinding_processor_absolute_path.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/rules/setup.bzl
+++ b/rules/setup.bzl
@@ -1,6 +1,5 @@
 # Dagger
 load("@bazel_common_dagger//:workspace_defs.bzl", "DAGGER_ARTIFACTS", "DAGGER_REPOSITORIES")
-load("@grab_bazel_common//android/tools:defs.bzl", "android_tools")
 load(
     "@grab_bazel_common//toolchains:toolchains.bzl",
     "register_common_toolchains",
@@ -30,16 +29,6 @@ load("@grab_bazel_common//rules/test:setup.bzl", "bazel_common_test_maven")
 load("@rules_android//:defs.bzl", "rules_android_workspace")
 load("@rules_android//rules:rules.bzl", "android_sdk_repository")
 
-
-# Setup android databinding compilation and optionally use patched android tools jar
-def _android(patched_android_tools):
-    native.bind(
-        name = "databinding_annotation_processor",
-        actual = "@grab_bazel_common//tools/android:compiler_annotation_processor",
-    )
-    if patched_android_tools:
-        android_tools()
-
 def _kotlin():
     kotlin_repositories(
         compiler_release = kotlinc_version(
@@ -63,7 +52,6 @@ def _rules_android_setup():
 
 
 def bazel_common_setup(
-        patched_android_tools = True,
         buildifier_version = BUILDIFIER_DEFAULT_VERSION,
         pinned_maven_install = True):
     #rules_proto_dependencies()
@@ -101,9 +89,9 @@ def bazel_common_setup(
             "xmlpull:xmlpull:1.1.3.1",
             "net.sf.kxml:kxml2:2.3.0",
             "com.squareup.moshi:moshi:1.11.0",
-            "org.jetbrains.kotlin:kotlin-stdlib:1.8.10",
-            "org.jetbrains.kotlin:kotlin-parcelize-compiler:1.8.10",
-            "org.jetbrains.kotlin:kotlin-parcelize-runtime:1.8.10",
+            "org.jetbrains.kotlin:kotlin-stdlib:2.1.0",
+            "org.jetbrains.kotlin:kotlin-parcelize-compiler:2.1.0",
+            "org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.0",
             "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4",
             "com.github.tschuchortdev:kotlin-compile-testing:1.5.0",
             "com.google.android.material:material:1.2.1",
@@ -121,7 +109,6 @@ def bazel_common_setup(
         fetch_sources = True,
     )
 
-    _android(patched_android_tools)
     _kotlin()
 
     rules_detekt_dependencies()


### PR DESCRIPTION
### Workspace Reordering
As part of Bazel externalization, `android tools` are migrated to rules_android. In order to load `rules_android`, it has to call `rules_android_prereqs()`. Inside that `prereqs`, it will call its [android_tools](https://github.com/bazelbuild/rules_android/blob/main/prereqs.bzl#L51C17-L51C29) that contains some jars, including `all_android_tools_deploy.jar` and other jars. 

With the old WORKSPACE setup, our android_tools will be called via `bazel_common_setup`, in which it'll be superseded by the `rules_android's`. The changes is to reorder `WORSKPACE` so our jars get called first and grab-bazel-common will use our patched tools.

**Changes:**
1. Created prereqs.bzl. Put the `android_tools()` calls there before `rules_android_prereqs` get called.
2. Added some [necessary calls](https://github.com/bazelbuild/rules_android/blob/main/prereqs.bzl#L51C17-L51C29) for `rules_android`


### Patches Registration
- Added some rules_android's patches to `BUILD.bzl` so it can be visible to repositories
- Include the patches in `rules_android`'s  http load in `repositories.bzl`
