### PR TITLE
Bazel 8 Migration - Compose Compiler Update

### DIFF
--- a/rules/android/compose/BUILD.bazel
+++ b/rules/android/compose/BUILD.bazel
@@ -2,13 +2,13 @@ load("@grab_bazel_common//rules:defs.bzl", "kotlin_library", "kt_compiler_plugin
 
 kt_compiler_plugin(
     name = "compose-compiler-plugin",
-    id = "androidx.compose.compiler.plugins.kotlin",
+    id = "org.jetbrains.kotlin.compose",
     options = {
         "experimentalStrongSkipping": "true",
     },
     target_embedded_compiler = True,
     deps = [
-        "@maven//:androidx_compose_compiler_compiler",
+        "@maven//:org_jetbrains_kotlin_kotlin_compose_compiler_plugin_embeddable",
     ],
 )
 


### PR DESCRIPTION
We have updated Kotlin compiler to 2.1 earlier, and when i tried to build a target with compose, it's failed with an error.
Turns out, starting from Kotlin 2.0, the old `androidx.compose.compiler:compiler` artifact and plugin ID are no longer available and [moved](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html) to Kotlin repository.

This PR follows the [migration guide](https://kotlinlang.org/docs/compose-compiler-migration-guide.html) to:
- Replace plugin ID from `androidx.compose.compiler.plugins.kotlin` to `org.jetbrains.kotlin.compose`
- Replace dep from `@maven//:androidx_compose_compiler_compiler` to
  `@maven//:org_jetbrains_kotlin_kotlin_compose_compiler_plugin_embeddable`

